### PR TITLE
Add basic prompt UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ AI prompts through innovative techniques inspired by genetic algorithms and mult
 *   Integration with various LLMs (OpenAI, Anthropic, Google)
 *   Performance tracking and evaluation of prompts
 *   API for programmatic access and integration
-*   User interface for managing and experimenting with prompts
+*   User interface for managing and experimenting with prompts (basic HTML interface available)
 
 ## Getting Started
 
@@ -64,7 +64,11 @@ PromptHelix also provides an API endpoint to trigger the genetic algorithm.
     ```
     Or you can open `http://127.0.0.1:8000/api/run-ga` in your web browser.
 
-3.  **Expected Response**:
+3.  **Try the Prompt Manager UI**:
+    Navigate to `http://127.0.0.1:8000/ui/prompts` to experiment with a simple
+    HTML interface for adding and viewing prompts.
+
+4.  **Expected Response**:
     The API will return a JSON response containing the best prompt found by the genetic algorithm and its fitness score:
     ```json
     {

--- a/prompthelix/api/routes.py
+++ b/prompthelix/api/routes.py
@@ -1,8 +1,18 @@
-from fastapi import APIRouter
+from pathlib import Path
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
 from prompthelix.orchestrator import main_ga_loop
 from prompthelix.genetics.engine import PromptChromosome
+from prompthelix.services.prompt_manager import PromptManager
 
 router = APIRouter()
+
+# Template configuration for simple HTML interface
+templates = Jinja2Templates(directory=str(Path(__file__).resolve().parent.parent / "templates"))
+
+# In-memory prompt manager instance
+prompt_manager = PromptManager()
 
 @router.get("/api/run-ga")
 async def run_ga_endpoint():
@@ -12,3 +22,34 @@ async def run_ga_endpoint():
     if isinstance(best, PromptChromosome):
         return {"best_prompt": best.to_prompt_string(), "fitness": best.fitness_score}
     return {"best_prompt": "", "fitness": 0.0}
+
+
+@router.get("/api/prompts")
+async def list_prompts():
+    """Return all stored prompts."""
+    return {"prompts": prompt_manager.list_prompts()}
+
+
+@router.post("/api/prompts")
+async def create_prompt(prompt: dict):
+    """Create a new prompt from posted JSON."""
+    content = prompt.get("content", "")
+    if not content:
+        return {"error": "content required"}
+    return prompt_manager.add_prompt(content)
+
+
+@router.get("/ui/prompts", response_class=HTMLResponse)
+async def prompts_page(request: Request):
+    """Render the HTML interface for managing prompts."""
+    return templates.TemplateResponse(
+        "prompts.html",
+        {"request": request, "prompts": prompt_manager.list_prompts()},
+    )
+
+
+@router.post("/ui/prompts", response_class=RedirectResponse)
+async def add_prompt_page(content: str = Form(...)):
+    """Handle form submission from the HTML interface."""
+    prompt_manager.add_prompt(content)
+    return RedirectResponse(url="/ui/prompts", status_code=303)

--- a/prompthelix/services/prompt_manager.py
+++ b/prompthelix/services/prompt_manager.py
@@ -1,0 +1,24 @@
+from typing import Dict, List
+from uuid import uuid4
+
+class PromptManager:
+    """Simple in-memory manager for prompts."""
+
+    def __init__(self) -> None:
+        self._prompts: Dict[str, str] = {}
+
+    def add_prompt(self, content: str) -> Dict[str, str]:
+        """Add a new prompt and return its data."""
+        prompt_id = str(uuid4())
+        self._prompts[prompt_id] = content
+        return {"id": prompt_id, "content": content}
+
+    def get_prompt(self, prompt_id: str) -> str | None:
+        """Retrieve a prompt by ID."""
+        return self._prompts.get(prompt_id)
+
+    def list_prompts(self) -> List[Dict[str, str]]:
+        """Return all prompts in a serializable form."""
+        return [
+            {"id": pid, "content": content} for pid, content in self._prompts.items()
+        ]

--- a/prompthelix/templates/prompts.html
+++ b/prompthelix/templates/prompts.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Prompt Manager</title>
+</head>
+<body>
+    <h1>Prompt Manager</h1>
+    <form action="/ui/prompts" method="post">
+        <textarea name="content" rows="4" cols="60" placeholder="Enter prompt text"></textarea><br>
+        <button type="submit">Add Prompt</button>
+    </form>
+
+    <h2>Existing Prompts</h2>
+    <ul>
+    {% for p in prompts %}
+        <li><pre>{{ p.content }}</pre></li>
+    {% else %}
+        <li>No prompts yet.</li>
+    {% endfor %}
+    </ul>
+</body>
+</html>

--- a/prompthelix/tests/test_prompt_endpoints.py
+++ b/prompthelix/tests/test_prompt_endpoints.py
@@ -1,0 +1,23 @@
+import unittest
+from fastapi.testclient import TestClient
+from prompthelix.main import app
+
+class TestPromptEndpoints(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+
+    def test_create_and_list_prompts(self):
+        create_resp = self.client.post("/api/prompts", json={"content": "hello"})
+        self.assertEqual(create_resp.status_code, 200)
+        data = create_resp.json()
+        self.assertIn("id", data)
+        self.assertEqual(data["content"], "hello")
+
+        list_resp = self.client.get("/api/prompts")
+        self.assertEqual(list_resp.status_code, 200)
+        listing = list_resp.json()
+        self.assertIn("prompts", listing)
+        self.assertTrue(any(p["id"] == data["id"] for p in listing["prompts"]))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add basic HTML prompt management interface and endpoints
- add in-memory PromptManager service
- document how to access the UI in README
- test prompt API endpoints

## Testing
- `python -m prompthelix.cli test`

------
https://chatgpt.com/codex/tasks/task_b_683fa156e7c08321905ac77bde29472a