### PR TITLE
Add TODO planning files

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,9 @@
+# Project TODO
+
+This file collects high-level tasks for improving **PromptHelix**.
+
+- [ ] Finish writing contribution guidelines and code of conduct
+- [ ] Create a full deployment guide (Docker, env setup, etc.)
+- [ ] Add CI configuration for automated testing
+- [ ] Review existing tests and update failing cases
+- [ ] Write a comprehensive LICENSE file (MIT expected)

--- a/prompthelix/TODO.md
+++ b/prompthelix/TODO.md
@@ -1,0 +1,8 @@
+# Package TODO
+
+General improvements for the `prompthelix` package.
+
+- [ ] Split modules into smaller packages where appropriate
+- [ ] Enforce consistent logging across modules
+- [ ] Provide configuration for enabling/disabling debug output
+- [ ] Clean up placeholder scripts in `tests/interactive` and `tests/oauth2`

--- a/prompthelix/agents/TODO.md
+++ b/prompthelix/agents/TODO.md
@@ -1,0 +1,9 @@
+# Agents TODO
+
+These tasks cover improvements to all agent classes.
+
+- [ ] Replace placeholder logic with real LLM interactions
+- [ ] Introduce inter-agent message bus for communication
+- [ ] Persist agent knowledge between runs
+- [ ] Add configuration options for each agent via `config.py`
+- [ ] Expand unit tests to cover edge cases for agents

--- a/prompthelix/api/TODO.md
+++ b/prompthelix/api/TODO.md
@@ -1,0 +1,9 @@
+# API TODO
+
+Tasks for improving FastAPI endpoints.
+
+- [ ] Add authentication and authorization
+- [ ] Implement pagination and filtering on list endpoints
+- [ ] Document all routes using OpenAPI annotations
+- [ ] Validate GA input parameters more strictly
+- [ ] Create integration tests for API error cases

--- a/prompthelix/docs/TODO.md
+++ b/prompthelix/docs/TODO.md
@@ -1,0 +1,8 @@
+# Documentation TODO
+
+Documentation updates and missing sections.
+
+- [ ] Expand usage examples in README
+- [ ] Document agent interactions with sequence diagrams
+- [ ] Add instructions for extending the genetic algorithm
+- [ ] Create troubleshooting guide for common errors

--- a/prompthelix/evaluation/TODO.md
+++ b/prompthelix/evaluation/TODO.md
@@ -1,0 +1,7 @@
+# Evaluation TODO
+
+Work needed for evaluation modules.
+
+- [ ] Develop metrics for prompt quality beyond placeholders
+- [ ] Integrate results with MetaLearnerAgent
+- [ ] Explore automated benchmarking against reference outputs

--- a/prompthelix/genetics/TODO.md
+++ b/prompthelix/genetics/TODO.md
@@ -1,0 +1,9 @@
+# Genetic Algorithm TODO
+
+Areas to enhance the GA engine.
+
+- [ ] Support parallel evaluation of chromosomes
+- [ ] Move mutation strategies into pluggable modules
+- [ ] Add persistence for populations between runs
+- [ ] Integrate StyleOptimizerAgent for smart mutation
+- [ ] Improve logging and monitoring of GA progress

--- a/prompthelix/models/TODO.md
+++ b/prompthelix/models/TODO.md
@@ -1,0 +1,9 @@
+# Models TODO
+
+Plans for completing ORM models.
+
+- [ ] Implement SQLAlchemy Base configuration
+- [ ] Flesh out User and Session models
+- [ ] Define PerformanceMetric schema and relationships
+- [ ] Create Alembic migrations for all tables
+- [ ] Add Pydantic schemas for new models

--- a/prompthelix/services/TODO.md
+++ b/prompthelix/services/TODO.md
@@ -1,0 +1,8 @@
+# Services TODO
+
+Items for service layer expansion.
+
+- [ ] Replace in-memory PromptManager with database-backed service
+- [ ] Add caching layer using Redis
+- [ ] Implement background workers for long-running tasks
+- [ ] Provide service interfaces for agent coordination

--- a/prompthelix/tests/TODO.md
+++ b/prompthelix/tests/TODO.md
@@ -1,0 +1,7 @@
+# Tests TODO
+
+Test suite improvements.
+
+- [ ] Update outdated API tests that expect old schemas
+- [ ] Mock external LLM calls consistently
+- [ ] Add coverage for services and CLI

--- a/prompthelix/utils/TODO.md
+++ b/prompthelix/utils/TODO.md
@@ -1,0 +1,7 @@
+# Utils TODO
+
+Additional helper utilities.
+
+- [ ] Provide logging helpers and formatting
+- [ ] Add common text processing functions
+- [ ] Offer helper to load templates from configuration


### PR DESCRIPTION
## Summary
- document pending tasks across project modules
- add TODO for agents, API, genetics, and other folders

## Testing
- `pytest -q` *(fails: TestPromptEndpoints.test_create_and_list_prompts, test_fitness_evaluator_init_no_api_key, TestFitnessEvaluator.test_evaluate_successful)*

------
https://chatgpt.com/codex/tasks/task_b_683fb4a4446c832182d2c63c70774718