### PR TITLE
Fix circular Base import

### DIFF
--- a/prompthelix/database.py
+++ b/prompthelix/database.py
@@ -1,14 +1,21 @@
 import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.ext.declarative import declarative_base
-from prompthelix.models.settings_models import APIKey
+from prompthelix.models.base import Base
 
 DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///./prompthelix.db")
 
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-Base = declarative_base()
+
+__all__ = [
+    "DATABASE_URL",
+    "engine",
+    "SessionLocal",
+    "Base",
+    "get_db",
+    "init_db",
+]
 
 def get_db():
     db = SessionLocal()

--- a/prompthelix/models/__init__.py
+++ b/prompthelix/models/__init__.py
@@ -1,4 +1,4 @@
-from prompthelix.database import Base
+from prompthelix.models.base import Base
 from .prompt_models import Prompt, PromptVersion
 
 __all__ = ["Base", "Prompt", "PromptVersion"]

--- a/prompthelix/models/base.py
+++ b/prompthelix/models/base.py
@@ -1,4 +1,9 @@
-# SQLAlchemy declarative base will be defined here.
-# from sqlalchemy.ext.declarative import declarative_base
-# Base = declarative_base()
-# TODO: Setup SQLAlchemy Base for ORM models.
+"""Shared SQLAlchemy declarative base used by all ORM models."""
+
+from sqlalchemy.orm import declarative_base
+
+# A single Base instance is used across the project so that models can be
+# registered without creating import cycles.
+Base = declarative_base()
+
+__all__ = ["Base"]

--- a/prompthelix/models/prompt_models.py
+++ b/prompthelix/models/prompt_models.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey, Float, JSON
 from sqlalchemy.orm import relationship
 from datetime import datetime
-from prompthelix.database import Base
+from prompthelix.models.base import Base
 
 class Prompt(Base):
     __tablename__ = "prompts"

--- a/prompthelix/models/settings_models.py
+++ b/prompthelix/models/settings_models.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, Integer, String, UniqueConstraint
-from prompthelix.database import Base # Assuming Base is accessible here
+from prompthelix.models.base import Base
 
 class APIKey(Base):
     __tablename__ = "api_keys"

--- a/prompthelix/tests/conftest.py
+++ b/prompthelix/tests/conftest.py
@@ -71,3 +71,9 @@ def test_client(db_engine):
 
     # Clean up overrides after tests
     app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client(test_client):
+    """Alias used by some tests."""
+    yield test_client


### PR DESCRIPTION
## Summary
- prevent circular import of `Base`
- re-export Base in `database`
- create alias fixture `client` for tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: assert statements and TypeError in tests)*

------
https://chatgpt.com/codex/tasks/task_b_683fb6240d78832187c99a5469ae6b42