### PR TITLE
Fix CLI run command with execution mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Execute the following command from the root of the project:
 python -m prompthelix.cli run
 ```
 
-This command runs the `run_ga.py` script via the CLI, which prints the progress of the genetic algorithm and the best prompt at the end of the process.
+By default the CLI runs in **TEST** mode which avoids real API calls. Use the `--mode REAL` flag to run with live LLM access (API keys required).
 
 ### API
 

--- a/prompthelix/cli.py
+++ b/prompthelix/cli.py
@@ -10,6 +10,8 @@ import sys
 import os
 import unittest
 
+from prompthelix.enums import ExecutionMode
+
 
 def main_cli():
     """
@@ -31,6 +33,12 @@ def main_cli():
     # "run" command
     run_parser = subparsers.add_parser("run", help="Run the PromptHelix application or a specific module")
     run_parser.add_argument("module", nargs="?", default="ga", help="Module to run (e.g., 'ga')")
+    run_parser.add_argument(
+        "--mode",
+        choices=["TEST", "REAL"],
+        default="TEST",
+        help="Execution mode for the GA run (defaults to TEST)",
+    )
 
 
     args = parser.parse_args()
@@ -120,7 +128,10 @@ def main_cli():
             default_population_size = 5 # Keep low for CLI example
             default_elitism_count = 1   # Keep low for CLI example
 
-            print(f"Using default parameters for GA: task='{default_task_desc}', generations={default_num_generations}, population={default_population_size}")
+            print(
+                f"Using default parameters for GA: task='{default_task_desc}', "
+                f"generations={default_num_generations}, population={default_population_size}, mode={args.mode}"
+            )
             
             try:
                 # Call main_ga_loop directly
@@ -131,6 +142,7 @@ def main_cli():
                     num_generations=default_num_generations,
                     population_size=default_population_size,
                     elitism_count=default_elitism_count,
+                    execution_mode=ExecutionMode(args.mode),
                     return_best=True  # Ensure it returns to potentially print results
                 )
                 if best_chromosome:

--- a/prompthelix/run_ga.py
+++ b/prompthelix/run_ga.py
@@ -7,6 +7,16 @@ import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from prompthelix.orchestrator import main_ga_loop
+from prompthelix.enums import ExecutionMode
 
 if __name__ == "__main__":
-    main_ga_loop()
+    # Default to TEST mode for simple standalone runs
+    main_ga_loop(
+        task_desc="Quick start demo",
+        keywords=["demo"],
+        num_generations=1,
+        population_size=2,
+        elitism_count=1,
+        execution_mode=ExecutionMode.TEST,
+        return_best=True,
+    )


### PR DESCRIPTION
## Summary
- allow selecting execution mode for the GA run via new `--mode` option in CLI
- default run mode is `TEST` and include mode info in README
- update run_ga script with example parameters

## Testing
- `python -m prompthelix.cli test` *(fails: PopulationManager, MetaLearnerAgent, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_684f6973844c8321b45104817c89a840