### PR TITLE
feat: Add LLM connectivity test script

### DIFF
--- a/prompthelix/docs/README.md
+++ b/prompthelix/docs/README.md
@@ -45,6 +45,37 @@ python -m unittest discover -s prompthelix/tests/unit
 ```
 (Further details on test execution and integration tests will be added as the project matures.)
 
+### LLM Connectivity Test
+
+A utility script `prompthelix/tests/test_llm_connectivity.py` is provided to test connectivity to a specified Large Language Model (LLM) provider and model. This script helps ensure that your environment is correctly configured and that the LLM services are accessible.
+
+**Running the Script:**
+
+You can run the script from the command line using Python:
+
+```bash
+python prompthelix/tests/test_llm_connectivity.py [options]
+```
+
+**Command-Line Arguments:**
+
+-   `--provider`: Specifies the LLM provider.
+    -   Default: `openai`
+    -   Example: `openai`, `claude`
+-   `--model`: Specifies the model name for the chosen provider.
+    -   Default: `gpt-3.5-turbo`
+    -   Example: `gpt-3.5-turbo`, `claude-2`
+
+**Usage Examples:**
+
+```bash
+python prompthelix/tests/test_llm_connectivity.py --provider openai --model gpt-3.5-turbo
+```
+
+```bash
+python prompthelix/tests/test_llm_connectivity.py --provider claude --model claude-2
+```
+
 ## Genetic Algorithm Engine
 
 PromptHelix employs a Genetic Algorithm (GA) to iteratively evolve and optimize prompts. This engine uses concepts like selection, crossover, and mutation to refine a population of prompts over generations, aiming to enhance their effectiveness based on defined fitness criteria. The GA is designed to interact with various specialized agents for tasks like initial prompt creation, fitness evaluation (based on LLM output simulation), and potentially for more advanced "smart" mutations.

--- a/prompthelix/tests/test_llm_connectivity.py
+++ b/prompthelix/tests/test_llm_connectivity.py
@@ -1,0 +1,42 @@
+from prompthelix.utils.llm_utils import call_llm_api
+import pytest
+import argparse
+
+def test_llm_connectivity(llm_provider: str, model: str):
+    """
+    Tests connectivity to the LLM API and checks if a response is received.
+    """
+    prompt = "Hello, this is a test."
+    try:
+        response = call_llm_api(prompt, llm_provider, model)
+        print(f"LLM Provider: {llm_provider}")
+        print(f"Model: {model}")
+        print(f"Prompt: {prompt}")
+        print(f"Response: {response}")
+        assert response is not None, "Response should not be None"
+        assert response != "", "Response should not be empty"
+    except Exception as e:
+        print(f"Error during LLM API call: {e}")
+        pytest.fail(f"LLM API call failed for {llm_provider} - {model}: {e}")
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Tests connectivity to a specified LLM provider and model.",
+        epilog="""Examples:
+  python test_llm_connectivity.py --provider openai --model gpt-3.5-turbo
+  python test_llm_connectivity.py --provider claude --model claude-2"""
+    )
+    parser.add_argument(
+        "--provider",
+        type=str,
+        default="openai",
+        help="LLM provider (e.g., openai, claude). This specifies which LLM provider to use.",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="gpt-3.5-turbo",
+        help="LLM model name (e.g., gpt-3.5-turbo, claude-2). This specifies which model of the provider to use.",
+    )
+    args = parser.parse_args()
+    test_llm_connectivity(args.provider, args.model)

--- a/prompthelix/tests/unit/test_llm_connectivity_tool.py
+++ b/prompthelix/tests/unit/test_llm_connectivity_tool.py
@@ -1,0 +1,97 @@
+import pytest
+from unittest.mock import patch, call
+from prompthelix.tests.test_llm_connectivity import test_llm_connectivity
+
+# Since the original script uses print for output and pytest.fail for errors,
+# we'll need to capture stdout/stderr or adapt the script if we want to assert specific error messages
+# For now, we will focus on the call_llm_api mock and its behavior.
+
+class TestLLMConnectivity:
+
+    @pytest.fixture
+    def mock_call_llm_api(self, mocker):
+        return mocker.patch('prompthelix.tests.test_llm_connectivity.call_llm_api')
+
+    def test_successful_connection(self, mock_call_llm_api, capsys):
+        """
+        Tests a successful connection scenario.
+        """
+        mock_call_llm_api.return_value = "Test response"
+        provider = "test_provider"
+        model = "test_model"
+
+        test_llm_connectivity(provider, model)
+
+        mock_call_llm_api.assert_called_once_with("Hello, this is a test.", provider, model)
+
+        captured = capsys.readouterr()
+        assert f"LLM Provider: {provider}" in captured.out
+        assert f"Model: {model}" in captured.out
+        assert "Response: Test response" in captured.out
+        # The original script's assertions will run, if they pass, this test passes.
+
+    def test_api_key_error_simulation(self, mock_call_llm_api, capsys):
+        """
+        Tests a scenario where call_llm_api raises a ValueError (simulating an API key issue).
+        The original script catches Exception and calls pytest.fail.
+        """
+        provider = "error_provider"
+        model = "error_model"
+        mock_call_llm_api.side_effect = ValueError("Simulated API Key Error")
+
+        with pytest.raises(pytest.fail.Exception): # Check if pytest.fail was called
+             test_llm_connectivity(provider, model)
+
+        mock_call_llm_api.assert_called_once_with("Hello, this is a test.", provider, model)
+
+        captured = capsys.readouterr()
+        assert f"Error during LLM API call: Simulated API Key Error" in captured.out
+        # The original script's pytest.fail will be triggered.
+
+    def test_empty_response(self, mock_call_llm_api, capsys):
+        """
+        Tests a scenario where the LLM API returns an empty string.
+        The original script's assertion `assert response != ""` should fail.
+        """
+        mock_call_llm_api.return_value = ""
+        provider = "empty_provider"
+        model = "empty_model"
+
+        with pytest.raises(AssertionError, match="Response should not be empty"):
+            test_llm_connectivity(provider, model)
+
+        mock_call_llm_api.assert_called_once_with("Hello, this is a test.", provider, model)
+
+        captured = capsys.readouterr()
+        assert f"LLM Provider: {provider}" in captured.out
+        assert f"Model: {model}" in captured.out
+        assert "Response: " in captured.out # Response is empty
+
+    def test_none_response(self, mock_call_llm_api, capsys):
+        """
+        Tests a scenario where the LLM API returns None.
+        The original script's assertion `assert response is not None` should fail.
+        """
+        mock_call_llm_api.return_value = None
+        provider = "none_provider"
+        model = "none_model"
+
+        with pytest.raises(AssertionError, match="Response should not be None"):
+            test_llm_connectivity(provider, model)
+
+        mock_call_llm_api.assert_called_once_with("Hello, this is a test.", provider, model)
+
+        captured = capsys.readouterr()
+        assert f"LLM Provider: {provider}" in captured.out
+        assert f"Model: {model}" in captured.out
+        assert "Response: None" in captured.out
+
+# To run these tests, you would typically use pytest in the terminal:
+# pytest prompthelix/tests/unit/test_llm_connectivity_tool.py
+# Ensure that `prompthelix.utils.llm_utils` is available in the PYTHONPATH
+# and `prompthelix.tests.test_llm_connectivity.call_llm_api` can be patched.
+
+# Note: The original script `test_llm_connectivity.py` has its own assertions
+# and calls `pytest.fail`. These tests are designed to work with that structure.
+# If `test_llm_connectivity` were to return values or raise specific custom exceptions,
+# these tests could be more direct in their assertions.


### PR DESCRIPTION
This commit introduces a new script `test_llm_connectivity.py` that allows you to test connectivity to configured LLM providers (OpenAI and Claude).

Key features:
- Option to specify LLM provider and model via command-line arguments.
- Debug output showing the provider, model, prompt, and response.
- Basic assertion to check for a non-empty response.
- Unit tests for the connectivity script, covering success, API errors, and empty responses.
- Documentation in `prompthelix/docs/README.md` explaining how to use the script.

This tool helps in diagnosing LLM connection issues and verifying API key configurations.