### PR TITLE
feat: Add LLM Test Interface and Usage Statistics

### DIFF
--- a/prompthelix/api/crud.py
+++ b/prompthelix/api/crud.py
@@ -1,9 +1,13 @@
 from sqlalchemy.orm import Session
 from sqlalchemy import func
-from typing import Optional
+from typing import Optional, List # Ensure List and Optional are imported
 from prompthelix.models import Prompt, PromptVersion
 from prompthelix.models.settings_models import APIKey
+from prompthelix.models.statistics_models import LLMUsageStatistic # Import the new model
 from prompthelix.schemas import PromptCreate, PromptVersionCreate
+# Assuming schemas for APIKey will be created in a later step,
+# for now, create_or_update_api_key will just take strings.
+# We might need: from prompthelix import schemas
 # Assuming schemas for APIKey will be created in a later step,
 # for now, create_or_update_api_key will just take strings.
 # We might need: from prompthelix import schemas
@@ -76,3 +80,35 @@ def create_or_update_api_key(db: Session, service_name: str, api_key_value: str)
     db.refresh(db_api_key)
     return db_api_key
 
+
+# CRUD functions for LLMUsageStatistic
+
+def get_llm_statistic(db: Session, service_name: str) -> Optional[LLMUsageStatistic]:
+    """Retrieves an LLM usage statistic entry by service name."""
+    return db.query(LLMUsageStatistic).filter(LLMUsageStatistic.llm_service == service_name).first()
+
+def create_llm_statistic(db: Session, service_name: str) -> LLMUsageStatistic:
+    """Creates a new LLM usage statistic entry with count 0."""
+    db_statistic = LLMUsageStatistic(llm_service=service_name, request_count=0)
+    db.add(db_statistic)
+    db.commit()
+    db.refresh(db_statistic)
+    return db_statistic
+
+def increment_llm_statistic(db: Session, service_name: str) -> LLMUsageStatistic:
+    """Increments the request count for an LLM service.
+    Creates the entry if it doesn't exist."""
+    db_statistic = get_llm_statistic(db, service_name=service_name)
+    if db_statistic:
+        db_statistic.request_count += 1
+    else:
+        # If no statistic entry exists, create one with count 1
+        db_statistic = LLMUsageStatistic(llm_service=service_name, request_count=1)
+        db.add(db_statistic)
+    db.commit()
+    db.refresh(db_statistic)
+    return db_statistic
+
+def get_all_llm_statistics(db: Session) -> List[LLMUsageStatistic]:
+    """Retrieves all LLM usage statistic entries."""
+    return db.query(LLMUsageStatistic).order_by(LLMUsageStatistic.llm_service).all()

--- a/prompthelix/api/routes.py
+++ b/prompthelix/api/routes.py
@@ -1,16 +1,20 @@
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
-from typing import List
+from typing import List, Optional # Ensure List, Optional are imported
 from datetime import datetime # For default prompt name
 
 from prompthelix.database import get_db
-from prompthelix.api import crud
-from prompthelix import schemas
+from prompthelix.api import crud # Assuming crud is already imported
+from prompthelix import schemas # Assuming schemas is already imported
+# Add specific schema imports if not covered by 'from prompthelix import schemas'
+from prompthelix.schemas import LLMTestRequest, LLMTestResponse, LLMStatistic as LLMStatisticSchema
+from prompthelix.utils import llm_utils # Import llm_utils
+
 from prompthelix.orchestrator import main_ga_loop
 from prompthelix.genetics.engine import PromptChromosome # To check instance type
 
-router = APIRouter()
+router = APIRouter() # This should already exist at the top of routes.py
 
 @router.post("/api/prompts", response_model=schemas.Prompt)
 def create_prompt_route(prompt: schemas.PromptCreate, db: Session = Depends(get_db)):
@@ -125,3 +129,65 @@ def run_ga_experiment(params: schemas.GAExperimentParams, db: Session = Depends(
 #         # Catch if main_ga_loop fails due to changed signature / missing params
 #         raise HTTPException(status_code=500, detail=f"Old GA endpoint failed: {e}")
 #     raise HTTPException(status_code=404, detail="Old GA endpoint: No best prompt found or error in execution.")
+
+
+@router.post("/api/llm/test_prompt", response_model=schemas.LLMTestResponse, name="test_llm_prompt")
+async def test_llm_prompt_route(
+    request_data: schemas.LLMTestRequest,
+    db: Session = Depends(get_db)
+):
+    """
+    Receives a prompt and an LLM service, calls the LLM,
+    logs the request, and returns the LLM's response.
+    """
+    try:
+        # Call the LLM API (passing db session if your llm_utils.call_llm_api expects it for key retrieval)
+        response_text = llm_utils.call_llm_api(
+            prompt=request_data.prompt_text,
+            provider=request_data.llm_service,
+            # model=None, # Or pass a specific model if desired/available from request_data
+            db=db
+        )
+
+        # Increment usage statistics
+        try:
+            crud.increment_llm_statistic(db=db, service_name=request_data.llm_service)
+        except Exception as e:
+            # Log this error but don't let it fail the main operation
+            # (e.g., if DB connection has an issue for stats but LLM call was successful)
+            print(f"Error incrementing LLM statistic for {request_data.llm_service}: {e}")
+            # Depending on policy, you might want to raise an alert here
+
+        return schemas.LLMTestResponse(
+            llm_service=request_data.llm_service,
+            response_text=response_text
+        )
+    except ValueError as ve: # Catch errors like "Unsupported LLM provider" or "API key not configured"
+        raise HTTPException(status_code=400, detail=str(ve))
+    except Exception as e:
+        # Catch-all for other unexpected errors during LLM call
+        print(f"Unexpected error in test_llm_prompt_route: {e}") # Log it
+        raise HTTPException(status_code=500, detail=f"An unexpected error occurred: {str(e)}")
+
+@router.get("/api/llm/statistics", response_model=List[schemas.LLMStatistic], name="get_llm_statistics")
+async def get_llm_statistics_route(db: Session = Depends(get_db)):
+    """
+    Retrieves usage statistics for all LLM services.
+    """
+    db_statistics = crud.get_all_llm_statistics(db=db)
+    # Convert model instances to Pydantic schemas if your response_model expects it
+    # and the conversion is not automatic (e.g. if orm_mode/from_attributes is not set everywhere)
+    # In this case, LLMStatistic schema has from_attributes = True, so direct return should work.
+    return db_statistics
+
+@router.get("/api/llm/available", response_model=List[str], name="get_available_llms")
+async def get_available_llms_route(db: Session = Depends(get_db)):
+    """
+    Retrieves a list of LLM services that are configured and available for use.
+    """
+    try:
+        available_llms = llm_utils.list_available_llms(db=db)
+        return available_llms
+    except Exception as e:
+        print(f"Error getting available LLMs: {e}") # Log it
+        raise HTTPException(status_code=500, detail="Failed to retrieve available LLMs.")

--- a/prompthelix/models/__init__.py
+++ b/prompthelix/models/__init__.py
@@ -1,4 +1,6 @@
 from prompthelix.models.base import Base
 from .prompt_models import Prompt, PromptVersion
+from .settings_models import APIKey # Ensure APIKey is also in __all__ if it wasn't explicitly
+from .statistics_models import LLMUsageStatistic # Add this import
 
-__all__ = ["Base", "Prompt", "PromptVersion"]
+__all__ = ["Base", "Prompt", "PromptVersion", "APIKey", "LLMUsageStatistic"] # Add LLMUsageStatistic here

--- a/prompthelix/models/statistics_models.py
+++ b/prompthelix/models/statistics_models.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, Integer, String
+from prompthelix.models.base import Base # Ensure Base is imported
+
+class LLMUsageStatistic(Base):
+    __tablename__ = "llm_usage_statistics"
+
+    id = Column(Integer, primary_key=True, index=True)
+    llm_service = Column(String, unique=True, index=True, nullable=False)
+    request_count = Column(Integer, default=0, nullable=False)
+
+    def __repr__(self):
+        return f"<LLMUsageStatistic(llm_service='{self.llm_service}', request_count={self.request_count})>"

--- a/prompthelix/schemas.py
+++ b/prompthelix/schemas.py
@@ -74,3 +74,19 @@ class APIKey(APIKeyBase):
 
     class Config:
         from_attributes = True # For ORM mode
+
+# New Schemas for LLM Testing and Statistics
+class LLMTestRequest(BaseModel):
+    llm_service: str = Field(..., description="The LLM service to use (e.g., OpenAI, Anthropic, Google)")
+    prompt_text: str = Field(..., description="The text prompt to send to the LLM")
+
+class LLMTestResponse(BaseModel):
+    llm_service: str = Field(..., description="The LLM service used")
+    response_text: str = Field(..., description="The text response from the LLM")
+
+class LLMStatistic(BaseModel):
+    llm_service: str = Field(..., description="The LLM service")
+    request_count: int = Field(..., description="The number of requests made to this LLM service")
+
+    class Config:
+        from_attributes = True # For ORM mode if we map it directly to a model later

--- a/prompthelix/templates/llm_tester.html
+++ b/prompthelix/templates/llm_tester.html
@@ -1,0 +1,221 @@
+{% extends "base.html" %}
+
+{% block title %}LLM Tester - PromptHelix{% endblock %}
+
+{% block content %}
+<div class="container mx-auto p-4">
+    <h1 class="text-2xl font-bold mb-4">LLM Test Interface</h1>
+
+    {% if error_message %}
+    <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
+        <strong class="font-bold">Error:</strong>
+        <span class="block sm:inline">{{ error_message }}</span>
+    </div>
+    {% endif %}
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <!-- LLM Test Form -->
+        <div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
+            <h2 class="text-xl font-semibold mb-3">Send Test Prompt</h2>
+            <form id="llmTestForm">
+                <div class="mb-4">
+                    <label class="block text-gray-700 text-sm font-bold mb-2" for="llm_service">
+                        Select LLM Service
+                    </label>
+                    <select id="llm_service" name="llm_service"
+                            class="shadow border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline">
+                        {% if available_llms %}
+                            {% for service in available_llms %}
+                            <option value="{{ service }}">{{ service }}</option>
+                            {% endfor %}
+                        {% else %}
+                            <option value="">No LLMs available (check API keys in settings)</option>
+                        {% endif %}
+                    </select>
+                </div>
+                <div class="mb-6">
+                    <label class="block text-gray-700 text-sm font-bold mb-2" for="prompt_text">
+                        Prompt Text
+                    </label>
+                    <textarea id="prompt_text" name="prompt_text" rows="10"
+                              class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 mb-3 leading-tight focus:outline-none focus:shadow-outline"
+                              placeholder="Enter your prompt here..."></textarea>
+                </div>
+                <div class="flex items-center justify-between">
+                    <button id="submitPrompt"
+                            class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+                            type="submit">
+                        Send Prompt
+                    </button>
+                </div>
+            </form>
+        </div>
+
+        <!-- LLM Response Display -->
+        <div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
+            <h2 class="text-xl font-semibold mb-3">LLM Response</h2>
+            <div id="llmResponseDisplay" class="bg-gray-100 p-4 rounded min-h-[200px] whitespace-pre-wrap">
+                {% if llm_response %}
+                    <p><strong>Service:</strong> {{ llm_response.llm_service }}</p>
+                    <p><strong>Response:</strong></p>
+                    <p>{{ llm_response.response_text }}</p>
+                {% else %}
+                    <p>Response will appear here...</p>
+                {% endif %}
+            </div>
+            <div id="responseSpinner" class="hidden text-center mt-4">
+                <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto"></div>
+                <p>Loading response...</p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Statistics Display -->
+    <div class="mt-8 bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
+        <h2 class="text-xl font-semibold mb-3">LLM Usage Statistics</h2>
+        <div id="statisticsDisplay">
+            {% if statistics %}
+            <table class="min-w-full table-auto">
+                <thead>
+                    <tr class="bg-gray-200 text-gray-600 uppercase text-sm leading-normal">
+                        <th class="py-3 px-6 text-left">LLM Service</th>
+                        <th class="py-3 px-6 text-left">Request Count</th>
+                    </tr>
+                </thead>
+                <tbody class="text-gray-600 text-sm font-light">
+                    {% for stat in statistics %}
+                    <tr class="border-b border-gray-200 hover:bg-gray-100">
+                        <td class="py-3 px-6 text-left whitespace-nowrap">{{ stat.llm_service }}</td>
+                        <td class="py-3 px-6 text-left">{{ stat.request_count }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% else %}
+            <p>No statistics available yet.</p>
+            {% endif %}
+        </div>
+    </div>
+
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const form = document.getElementById('llmTestForm');
+        const responseDisplay = document.getElementById('llmResponseDisplay');
+        const statisticsDisplay = document.getElementById('statisticsDisplay');
+        const submitButton = document.getElementById('submitPrompt');
+        const responseSpinner = document.getElementById('responseSpinner');
+        const llmServiceSelect = document.getElementById('llm_service');
+
+        // Function to fetch and update statistics
+        async function fetchStatistics() {
+            try {
+                const response = await fetch("{{ request.url_for('get_llm_statistics') }}");
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+                const statsData = await response.json();
+
+                let statsHtml = '<p>No statistics available yet.</p>';
+                if (statsData && statsData.length > 0) {
+                    statsHtml = `
+                        <table class="min-w-full table-auto">
+                            <thead>
+                                <tr class="bg-gray-200 text-gray-600 uppercase text-sm leading-normal">
+                                    <th class="py-3 px-6 text-left">LLM Service</th>
+                                    <th class="py-3 px-6 text-left">Request Count</th>
+                                </tr>
+                            </thead>
+                            <tbody class="text-gray-600 text-sm font-light">`;
+                    statsData.forEach(stat => {
+                        statsHtml += \`
+                            <tr class="border-b border-gray-200 hover:bg-gray-100">
+                                <td class="py-3 px-6 text-left whitespace-nowrap">\${stat.llm_service}</td>
+                                <td class="py-3 px-6 text-left">\${stat.request_count}</td>
+                            </tr>\`;
+                    });
+                    statsHtml += '</tbody></table>';
+                }
+                statisticsDisplay.innerHTML = statsHtml;
+            } catch (error) {
+                console.error("Error fetching statistics:", error);
+                statisticsDisplay.innerHTML = "<p class='text-red-500'>Error loading statistics.</p>";
+            }
+        }
+
+        // Function to fetch and update available LLMs (e.g. if keys change)
+        // Not strictly necessary for this version if page reloads/re-renders often enough
+        // but good for robustness if settings can change without full page reload.
+        async function fetchAvailableLLMs() {
+            try {
+                const response = await fetch("{{ request.url_for('get_available_llms') }}");
+                if (!response.ok) {
+                    throw new Error(\`HTTP error! status: \${response.status}\`);
+                }
+                const llmsData = await response.json();
+
+                let optionsHtml = '<option value="">No LLMs available</option>';
+                if (llmsData && llmsData.length > 0) {
+                    optionsHtml = llmsData.map(service => \`<option value="\${service}">\${service}</option>\`).join('');
+                }
+                llmServiceSelect.innerHTML = optionsHtml;
+            } catch (error) {
+                console.error("Error fetching available LLMs:", error);
+                llmServiceSelect.innerHTML = "<option value=''>Error loading LLMs</option>";
+            }
+        }
+
+        // Initial fetch of LLMs (can be useful if settings change and UI is reloaded via JS)
+        // fetchAvailableLLMs(); // Commented out as initial data is passed from server-side render
+
+        form.addEventListener('submit', async function (event) {
+            event.preventDefault();
+            submitButton.disabled = true;
+            responseSpinner.classList.remove('hidden');
+            responseDisplay.innerHTML = '<p>Processing...</p>';
+
+            const formData = new FormData(form);
+            const data = {
+                llm_service: formData.get('llm_service'),
+                prompt_text: formData.get('prompt_text')
+            };
+
+            try {
+                const response = await fetch("{{ request.url_for('test_llm_prompt') }}", {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        // Include CSRF token if your app uses them for POST requests
+                    },
+                    body: JSON.stringify(data)
+                });
+
+                if (!response.ok) {
+                    const errorData = await response.json();
+                    throw new Error(errorData.detail || \`HTTP error! status: \${response.status}\`);
+                }
+
+                const result = await response.json();
+                responseDisplay.innerHTML = \`
+                    <p><strong>Service:</strong> \${result.llm_service}</p>
+                    <p><strong>Response:</strong></p>
+                    <div class="whitespace-pre-wrap">\${result.response_text}</div>\`;
+
+                // Refresh statistics after successful prompt
+                fetchStatistics();
+
+            } catch (error) {
+                console.error('Error sending prompt:', error);
+                responseDisplay.innerHTML = \`<p class="text-red-500"><strong>Error:</strong> \${error.message}</p>\`;
+            } finally {
+                submitButton.disabled = false;
+                responseSpinner.classList.add('hidden');
+            }
+        });
+
+        // Initial fetch of statistics on page load
+        // fetchStatistics(); // Already rendered server-side, but can be enabled for dynamic updates
+    });
+</script>
+{% endblock %}

--- a/prompthelix/ui_routes.py
+++ b/prompthelix/ui_routes.py
@@ -15,6 +15,7 @@ from prompthelix.api import crud            # Ensure this is imported
 from prompthelix import schemas # Import all schemas
 from prompthelix.enums import ExecutionMode # Added import
 from prompthelix.agents.base import BaseAgent
+from prompthelix.utils import llm_utils # Added import
 
 
 router = APIRouter()
@@ -286,3 +287,57 @@ async def save_api_keys_settings(
         redirect_url += f"&error={error_status}"
 
     return RedirectResponse(url=redirect_url, status_code=HTTP_303_SEE_OTHER)
+
+
+@router.get("/ui/llm_tester", name="llm_tester_ui")
+async def llm_tester_ui(request: Request, db: Session = Depends(get_db)):
+    """
+    Renders the LLM Tester UI page.
+    Fetches available LLMs and current statistics to display.
+    """
+    available_llms = []
+    statistics = []
+    error_message = None
+    try:
+        # Option 1: Call llm_utils directly (if it's simple and doesn't require async client calls)
+        available_llms = llm_utils.list_available_llms(db=db)
+
+        # Option 2: Call your own API endpoint (if you prefer to keep UI routes calling API routes)
+        # This requires httpx and careful handling of base_url if app is not fully running in this context
+        # For simplicity, direct util call is used here.
+        # async with httpx.AsyncClient(app=request.app, base_url=request.base_url) as client:
+        #     response_available = await client.get(request.url_for('get_available_llms'))
+        #     response_available.raise_for_status()
+        #     available_llms = response_available.json()
+
+        #     response_stats = await client.get(request.url_for('get_llm_statistics'))
+        #     response_stats.raise_for_status()
+        #     statistics_raw = response_stats.json()
+        #     # Convert to schema if necessary, though API should return them as per schema
+        #     statistics = [schemas.LLMStatistic(**stat) for stat in statistics_raw]
+
+        db_statistics = crud.get_all_llm_statistics(db=db)
+        # Convert to LLMStatistic schema if needed, but crud returns models.
+        # The template might directly use model attributes or you can convert here.
+        # For consistency with plan schema names:
+        statistics = [schemas.LLMStatistic(llm_service=stat.llm_service, request_count=stat.request_count) for stat in db_statistics]
+
+
+    except HTTPException as http_exc: # Catch HTTP exceptions from potential API calls
+        error_message = f"API Error: {http_exc.detail}"
+    except Exception as e:
+        error_message = f"An unexpected error occurred while fetching data: {str(e)}"
+        # Log this error as well
+        print(f"Error in llm_tester_ui: {e}")
+
+    return templates.TemplateResponse(
+        "llm_tester.html",
+        {
+            "request": request,
+            "available_llms": available_llms,
+            "statistics": statistics,
+            "error_message": error_message,
+            "llm_response": None, # For initial state
+            "submitted_prompt": None # For initial state
+        }
+    )

--- a/prompthelix/utils/llm_utils.py
+++ b/prompthelix/utils/llm_utils.py
@@ -1,60 +1,73 @@
 from prompthelix.config import settings # Import the settings object
 import logging
+from sqlalchemy.orm import Session # Added for list_available_llms
+from prompthelix.api import crud # Added for list_available_llms
+from prompthelix.config import get_openai_api_key, get_anthropic_api_key, get_google_api_key
+from typing import Optional # Added for Optional type hint
 
 logger = logging.getLogger(__name__)
 
-def call_openai_api(prompt: str, model: str = "gpt-3.5-turbo") -> str:
-    """
-    Calls the OpenAI API with the given prompt and model.
-    (This is a placeholder and needs actual implementation of the API call)
-    """
-    # API key is now accessed via settings.OPENAI_API_KEY
-    # The settings object loads it from environment or DB
-    api_key = settings.OPENAI_API_KEY
-    if not api_key or api_key == "YOUR_OPENAI_KEY_HERE_CONFIG": # Check against placeholder in config if env var not set
-        logger.error("OpenAI API key not configured in environment variables (OPENAI_API_KEY).")
-        raise ValueError("OpenAI API key not configured.")
+def call_openai_api(prompt: str, model: str = "gpt-3.5-turbo", db: Session = None) -> str:
+    api_key = get_openai_api_key(db) # Use the function from config.py
 
-    # Actual OpenAI API call logic would go here using 'api_key'
-    logger.info(f"Simulating OpenAI API call with model {model} (key starts with: {api_key[:5]}... if set). Prompt: {prompt[:100]}...")
-    # Simulate API response for now
-    if "requirements" in prompt:
-        return "Parsed requirements: Feature X, Feature Y (Simulated OpenAI)"
-    elif "template" in prompt:
-        return "Selected template: Template A (Simulated OpenAI)"
-    elif "genes" in prompt:
-        return "Populated genes: Gene 1, Gene 2 (Simulated OpenAI)"
-    return "OpenAI API response (Simulated)"
+    if not api_key: # Simplified check, as get_..._api_key handles fallback
+        logger.error("OpenAI API key not configured.")
+        raise ValueError("OpenAI API key not configured. Please set it in the settings or environment.")
 
-def call_claude_api(prompt: str, model: str = "claude-2") -> str:
-    """
-    Calls the Claude API with the given prompt and model.
-    (This is a placeholder and needs actual implementation of the API call)
-    """
-    # API key is now accessed via settings.ANTHROPIC_API_KEY (assuming Claude is Anthropic)
-    api_key = settings.ANTHROPIC_API_KEY
-    if not api_key or api_key == "YOUR_CLAUDE_KEY_HERE_CONFIG": # Check against placeholder in config if env var not set
-        logger.error("Anthropic (Claude) API key not configured in environment variables (ANTHROPIC_API_KEY).")
-        raise ValueError("Anthropic (Claude) API key not configured.")
+    logger.info(f"Simulating OpenAI API call with model {model} (key exists). Prompt: {prompt[:100]}...")
+    return f"Simulated OpenAI API response for model {model}: '{prompt}'"
 
-    # Actual Claude API call logic would go here using 'api_key'
-    logger.info(f"Simulating Claude API call with model {model} (key starts with: {api_key[:5]}... if set). Prompt: {prompt[:100]}...")
-    # Simulate API response for now
-    if "requirements" in prompt:
-        return "Parsed requirements: Feature X, Feature Y (Simulated Claude)"
-    elif "template" in prompt:
-        return "Selected template: Template A (Simulated Claude)"
-    elif "genes" in prompt:
-        return "Populated genes: Gene 1, Gene 2 (Simulated Claude)"
-    return "Claude API response (Simulated)"
+def call_claude_api(prompt: str, model: str = "claude-2", db: Session = None) -> str:
+    api_key = get_anthropic_api_key(db) # Use the function from config.py
 
-def call_llm_api(prompt: str, provider: str = "openai", model: str = None) -> str:
-    """
-    Calls the specified LLM API (OpenAI or Claude).
-    """
-    if provider == "openai":
-        return call_openai_api(prompt, model=model if model else "gpt-3.5-turbo")
-    elif provider == "claude":
-        return call_claude_api(prompt, model=model if model else "claude-2")
+    if not api_key:
+        logger.error("Anthropic (Claude) API key not configured.")
+        raise ValueError("Anthropic (Claude) API key not configured. Please set it in the settings or environment.")
+
+    logger.info(f"Simulating Claude API call with model {model} (key exists). Prompt: {prompt[:100]}...")
+    return f"Simulated Claude API response for model {model}: '{prompt}'"
+
+def call_google_api(prompt: str, model: str = "gemini-pro", db: Session = None) -> str:
+    api_key = get_google_api_key(db) # Use the function from config.py
+
+    if not api_key:
+        logger.error("Google API key not configured.")
+        raise ValueError("Google API key not configured. Please set it in the settings or environment.")
+
+    logger.info(f"Simulating Google API call with model {model} (key exists). Prompt: {prompt[:100]}...")
+    return f"Simulated Google API response for model {model}: '{prompt}'"
+
+def call_llm_api(prompt: str, provider: str, model: Optional[str] = None, db: Session = None) -> str:
+    logger.info(f"call_llm_api invoked with provider: {provider}, model: {model}")
+    provider_lower = provider.lower()
+
+    if provider_lower == "openai":
+        model_to_use = model if model else "gpt-3.5-turbo"
+        return call_openai_api(prompt, model=model_to_use, db=db)
+    elif provider_lower == "anthropic":
+        model_to_use = model if model else "claude-2"
+        return call_claude_api(prompt, model=model_to_use, db=db)
+    elif provider_lower == "google":
+        model_to_use = model if model else "gemini-pro"
+        return call_google_api(prompt, model=model_to_use, db=db)
     else:
+        logger.error(f"Unsupported LLM provider: {provider}")
         raise ValueError(f"Unsupported LLM provider: {provider}")
+
+def list_available_llms(db: Session) -> list[str]:
+    available_services = []
+    # These are the services also considered in `ui_routes.SUPPORTED_LLM_SERVICES`
+    # and `config.py` for API key retrieval.
+    # The name string (e.g., "OPENAI") should match what `crud.get_api_key` expects.
+    service_checks = [
+        ("OPENAI", get_openai_api_key(db)),
+        ("ANTHROPIC", get_anthropic_api_key(db)),
+        ("GOOGLE", get_google_api_key(db)),
+    ]
+
+    for service_name, api_key_value in service_checks:
+        if api_key_value: # If a key is found (either from DB or environment via config functions)
+            available_services.append(service_name)
+
+    logger.info(f"Available LLMs based on configured keys: {available_services}")
+    return available_services


### PR DESCRIPTION
This commit introduces a new feature allowing you to send test prompts to configured Large Language Models (LLMs) directly from the UI and view usage statistics.

Key changes include:

1.  **LLM Testing UI:**
    *   A new page at `/ui/llm_tester` provides a form to select an LLM
        service (OpenAI, Anthropic, Google), input a prompt, and view the
        LLM's response.
    *   Available LLMs in the dropdown are dynamically populated based on
        whether their API keys are configured in the settings.

2.  **LLM Usage Statistics:**
    *   The application now tracks the number of requests made to each LLM
        service.
    *   These statistics are displayed on the LLM Tester page and are
        updated after each test prompt.

3.  **Backend Implementation:**
    *   Added new Pydantic schemas (`LLMTestRequest`, `LLMTestResponse`,
        `LLMStatistic`) for data validation and serialization.
    *   Updated `llm_utils.py` to include support for Google LLMs (simulated)
        and a function to list available LLMs based on database-stored/env API keys.
    *   Created a new database model `LLMUsageStatistic` and corresponding
        CRUD operations to store and manage request counts.
    *   Added new API endpoints:
        *   `POST /api/llm/test_prompt`: To send a prompt to an LLM.
        *   `GET /api/llm/statistics`: To retrieve usage statistics.
        *   `GET /api/llm/available`: To list configured LLMs.

4.  **Configuration & Settings:**
    *   Verified that Google LLM is included in the supported services list
        for API key configuration in the settings page.

Simulated API calls are used in `llm_utils.py` for now. Future work could involve implementing actual HTTP calls to the LLM providers.