### PR TITLE
I've implemented a persistence layer, allowing me to save and load my…

### DIFF
--- a/prompthelix/tests/unit/test_agent_messaging.py
+++ b/prompthelix/tests/unit/test_agent_messaging.py
@@ -1,0 +1,120 @@
+import unittest
+from unittest.mock import MagicMock
+from datetime import datetime
+
+from prompthelix.message_bus import MessageBus
+from prompthelix.agents.base import BaseAgent # For creating a mock agent
+
+class MockAgent(BaseAgent):
+    """A simple agent for testing messaging that inherits from BaseAgent."""
+    def __init__(self, agent_id: str, message_bus=None):
+        super().__init__(agent_id, message_bus)
+        self.received_ping_payload = None
+
+    def process_request(self, request_data: dict) -> dict:
+        # Not the primary focus for ping tests, but good to have a basic implementation
+        return {"status": "processed", "data_received": request_data}
+
+    # Override receive_message if we want to capture specific things for asserts,
+    # but for ping, BaseAgent's implementation is what we are testing.
+    # However, if we want to check payload of ping, we might need to.
+    # BaseAgent's receive_message already logs and returns the pong for "ping".
+    # Let's assume BaseAgent's receive_message is sufficient for ping test.
+
+
+class TestAgentMessaging(unittest.TestCase):
+
+    def setUp(self):
+        self.message_bus = MessageBus()
+        self.agent1 = MockAgent(agent_id="Agent1", message_bus=self.message_bus)
+        self.agent2 = MockAgent(agent_id="Agent2", message_bus=self.message_bus)
+        self.message_bus.register(self.agent1.agent_id, self.agent1)
+        self.message_bus.register(self.agent2.agent_id, self.agent2)
+
+    def test_ping_functionality(self):
+        """Test that agent1 can ping agent2 and receive a pong response."""
+        ping_payload = {"data": "ping_from_agent1"}
+        response = self.agent1.send_message(
+            recipient_agent_id=self.agent2.agent_id,
+            message_content=ping_payload,
+            message_type="ping"
+        )
+
+        self.assertIsInstance(response, dict)
+        self.assertEqual(response.get("status"), "pong")
+        self.assertEqual(response.get("agent_id"), self.agent2.agent_id)
+        self.assertIn("timestamp", response)
+        try:
+            datetime.fromisoformat(response["timestamp"]) # Check if timestamp is valid ISO format
+        except ValueError:
+            self.fail("Ping response timestamp is not a valid ISO format string.")
+
+    def test_message_to_non_existent_agent(self):
+        """Test dispatching a message to a non-existent agent via MessageBus."""
+        message_to_non_existent = {
+            "sender_id": self.agent1.agent_id,
+            "recipient_id": "NonExistentAgent",
+            "message_type": "test_message",
+            "payload": {"data": "hello"}
+        }
+        response = self.message_bus.dispatch_message(message_to_non_existent)
+
+        self.assertIsInstance(response, dict)
+        self.assertEqual(response.get("status"), "error")
+        self.assertIn("Recipient agent 'NonExistentAgent' not found", response.get("error", ""))
+
+    def test_send_message_failure_no_bus(self):
+        """Test that an agent without a message bus fails to send a message gracefully."""
+        agent_no_bus = MockAgent(agent_id="AgentNoBus", message_bus=None)
+        response = agent_no_bus.send_message(
+            recipient_agent_id=self.agent1.agent_id,
+            message_content={"data": "hello"},
+            message_type="test_message"
+        )
+
+        self.assertIsInstance(response, dict)
+        self.assertEqual(response.get("status"), "error")
+        self.assertEqual(response.get("error"), "No message bus available to send message.")
+
+    def test_send_message_recipient_no_receive_method(self):
+        """Test sending a message to an agent that doesn't have receive_message."""
+        faulty_agent_instance = object() # A plain object that doesn't have receive_message
+        self.message_bus.register("FaultyAgent", faulty_agent_instance)
+
+        response = self.agent1.send_message(
+            recipient_agent_id="FaultyAgent",
+            message_content={"data": "hello"},
+            message_type="test_message"
+        )
+        self.assertIsInstance(response, dict)
+        self.assertEqual(response.get("status"), "error")
+        self.assertIn("does not have a callable 'receive_message' method", response.get("error", ""))
+
+    def test_send_message_recipient_receive_method_exception(self):
+        """Test sending a message to an agent whose receive_message raises an exception."""
+        agent_with_faulty_receive = MockAgent(agent_id="FaultyReceiveAgent", message_bus=self.message_bus)
+
+        # Mock the receive_message to raise an exception
+        original_receive_message = agent_with_faulty_receive.receive_message
+        def faulty_receive(*args, **kwargs):
+            raise RuntimeError("Simulated receive error")
+        agent_with_faulty_receive.receive_message = MagicMock(side_effect=faulty_receive)
+
+        self.message_bus.register(agent_with_faulty_receive.agent_id, agent_with_faulty_receive)
+
+        response = self.agent1.send_message(
+            recipient_agent_id=agent_with_faulty_receive.agent_id,
+            message_content={"data": "hello"},
+            message_type="test_message"
+        )
+        self.assertIsInstance(response, dict)
+        self.assertEqual(response.get("status"), "error")
+        self.assertIn(f"Error delivering message to agent '{agent_with_faulty_receive.agent_id}'", response.get("error", ""))
+        self.assertIn("Simulated receive error", response.get("error", ""))
+
+        # Restore original method if necessary for other tests or cleanup, though for this test structure it's fine.
+        agent_with_faulty_receive.receive_message = original_receive_message
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/prompthelix/tests/unit/test_agent_persistence.py
+++ b/prompthelix/tests/unit/test_agent_persistence.py
@@ -1,0 +1,185 @@
+import unittest
+import tempfile
+import os
+import json
+from unittest.mock import patch, mock_open # For MetaLearner, logging checks
+
+# Import Agents
+from prompthelix.agents.domain_expert import DomainExpertAgent
+from prompthelix.agents.architect import PromptArchitectAgent
+from prompthelix.agents.critic import PromptCriticAgent
+from prompthelix.agents.style_optimizer import StyleOptimizerAgent
+from prompthelix.agents.results_evaluator import ResultsEvaluatorAgent
+from prompthelix.agents.meta_learner import MetaLearnerAgent
+from prompthelix.message_bus import MessageBus # MetaLearner needs a bus
+
+class TestAgentPersistence(unittest.TestCase):
+    def setUp(self):
+        # Create a temporary directory to store knowledge files
+        self.temp_dir = tempfile.TemporaryDirectory()
+        # MetaLearnerAgent requires a message bus
+        self.mock_bus = MessageBus()
+
+    def tearDown(self):
+        # Clean up the temporary directory
+        self.temp_dir.cleanup()
+
+    def _get_temp_filepath(self, filename_suffix):
+        return os.path.join(self.temp_dir.name, f"test_{filename_suffix}.json")
+
+    # Generic test methods to be reused by specific agent tests where possible
+    def _test_default_load_and_initial_save(self, agent_class, default_knowledge_attr, **kwargs):
+        temp_file = self._get_temp_filepath(f"{agent_class.__name__}_defaults")
+
+        # Ensure file does not exist initially for a clean test of initial save behavior
+        if os.path.exists(temp_file):
+            os.remove(temp_file)
+
+        agent = agent_class(knowledge_file_path=temp_file, **kwargs)
+        default_knowledge = getattr(agent, default_knowledge_attr)
+        self.assertTrue(default_knowledge, f"Default knowledge for {agent_class.__name__} should not be empty.")
+
+        # Check if save_knowledge was called (file should now exist with default content)
+        self.assertTrue(os.path.exists(temp_file), f"Knowledge file {temp_file} should have been created with defaults.")
+        with open(temp_file, 'r') as f:
+            loaded_from_file = json.load(f)
+        self.assertEqual(default_knowledge, loaded_from_file, f"File content should match default knowledge for {agent_class.__name__}.")
+
+    def _test_save_and_reload_modified_knowledge(self, agent_class, knowledge_attr, modification_func, **kwargs):
+        temp_file = self._get_temp_filepath(f"{agent_class.__name__}_modified")
+
+        agent1 = agent_class(knowledge_file_path=temp_file, **kwargs)
+
+        # Perform modification
+        modification_func(getattr(agent1, knowledge_attr))
+        modified_knowledge_agent1 = getattr(agent1, knowledge_attr)
+
+        agent1.save_knowledge()
+
+        agent2 = agent_class(knowledge_file_path=temp_file, **kwargs)
+        reloaded_knowledge_agent2 = getattr(agent2, knowledge_attr)
+
+        self.assertEqual(modified_knowledge_agent1, reloaded_knowledge_agent2,
+                         f"Reloaded knowledge should match modified knowledge for {agent_class.__name__}.")
+
+    def _test_corrupted_file_fallback(self, agent_class, default_knowledge_attr, **kwargs):
+        temp_file = self._get_temp_filepath(f"{agent_class.__name__}_corrupted")
+
+        # Create a dummy valid file first to ensure agent would normally load it
+        agent_dummy = agent_class(knowledge_file_path=temp_file, **kwargs)
+        agent_dummy.save_knowledge() # Save defaults
+
+        # Now corrupt the file
+        with open(temp_file, 'w') as f:
+            f.write("this is not valid json")
+
+        with patch('logging.error') as mock_log_error:
+            agent = agent_class(knowledge_file_path=temp_file, **kwargs)
+            default_knowledge = getattr(agent, default_knowledge_attr)
+            original_default_knowledge = agent._get_default_knowledge() if hasattr(agent, '_get_default_knowledge') else \
+                                         agent._get_default_templates() if hasattr(agent, '_get_default_templates') else \
+                                         agent._get_default_critique_rules() if hasattr(agent, '_get_default_critique_rules') else \
+                                         agent._get_default_style_rules() if hasattr(agent, '_get_default_style_rules') else \
+                                         agent._get_default_metrics_config() if hasattr(agent, '_get_default_metrics_config') else {} # Add MetaLearner specific one if needed
+
+            self.assertEqual(default_knowledge, original_default_knowledge,
+                             f"Agent {agent_class.__name__} should fall back to default knowledge on corrupted file.")
+            mock_log_error.assert_called() # Check that an error was logged
+
+    # --- DomainExpertAgent Tests ---
+    def test_dea_default_load(self):
+        self._test_default_load_and_initial_save(DomainExpertAgent, 'knowledge_base')
+
+    def test_dea_save_reload_modified(self):
+        def modify_dea_knowledge(kb):
+            kb["new_domain"] = {"keywords": ["test1"]}
+        self._test_save_and_reload_modified_knowledge(DomainExpertAgent, 'knowledge_base', modify_dea_knowledge)
+
+    def test_dea_corrupted_fallback(self):
+        self._test_corrupted_file_fallback(DomainExpertAgent, 'knowledge_base')
+
+    # --- PromptArchitectAgent Tests ---
+    def test_paa_default_load(self):
+        self._test_default_load_and_initial_save(PromptArchitectAgent, 'templates')
+
+    def test_paa_save_reload_modified(self):
+        def modify_paa_templates(tpl):
+            tpl["new_template_test"] = {"instruction": "test instruction"}
+        self._test_save_and_reload_modified_knowledge(PromptArchitectAgent, 'templates', modify_paa_templates)
+
+    def test_paa_corrupted_fallback(self):
+        self._test_corrupted_file_fallback(PromptArchitectAgent, 'templates')
+
+    # --- PromptCriticAgent Tests ---
+    def test_pca_default_load(self):
+        self._test_default_load_and_initial_save(PromptCriticAgent, 'critique_rules')
+
+    def test_pca_save_reload_modified(self):
+        def modify_pca_rules(rules):
+            if isinstance(rules, list) and rules: # Default rules are a list
+                 rules[0]["message"] = "Modified test message"
+            else: # If it became a dict somehow or empty
+                rules.append({"name": "TestRule", "message": "Modified test message"})
+
+        self._test_save_and_reload_modified_knowledge(PromptCriticAgent, 'critique_rules', modify_pca_rules)
+
+    def test_pca_corrupted_fallback(self):
+        self._test_corrupted_file_fallback(PromptCriticAgent, 'critique_rules')
+
+    # --- StyleOptimizerAgent Tests ---
+    def test_soa_default_load(self):
+        self._test_default_load_and_initial_save(StyleOptimizerAgent, 'style_rules')
+
+    def test_soa_save_reload_modified(self):
+        def modify_soa_rules(rules):
+            rules["new_style_test"] = {"replace": {"old": "new"}}
+        self._test_save_and_reload_modified_knowledge(StyleOptimizerAgent, 'style_rules', modify_soa_rules)
+
+    def test_soa_corrupted_fallback(self):
+        self._test_corrupted_file_fallback(StyleOptimizerAgent, 'style_rules')
+
+    # --- ResultsEvaluatorAgent Tests ---
+    def test_rea_default_load(self):
+        self._test_default_load_and_initial_save(ResultsEvaluatorAgent, 'evaluation_metrics_config')
+
+    def test_rea_save_reload_modified(self):
+        def modify_rea_config(config):
+            config["new_metric_test"] = "test_value"
+        self._test_save_and_reload_modified_knowledge(ResultsEvaluatorAgent, 'evaluation_metrics_config', modify_rea_config)
+
+    def test_rea_corrupted_fallback(self):
+        self._test_corrupted_file_fallback(ResultsEvaluatorAgent, 'evaluation_metrics_config')
+
+    # --- MetaLearnerAgent Tests ---
+    # MetaLearnerAgent's _get_default_knowledge initializes knowledge_base with specific keys.
+    # Its load_knowledge also initializes these keys if they are missing after loading from file.
+    # So, the "default_knowledge_attr" is 'knowledge_base', but the comparison needs to be against
+    # what _get_default_knowledge() returns.
+
+    def test_mla_default_load(self):
+         self._test_default_load_and_initial_save(MetaLearnerAgent, 'knowledge_base', message_bus=self.mock_bus)
+
+    def test_mla_save_reload_modified(self):
+        def modify_mla_knowledge(kb):
+            kb["successful_prompt_features"]["new_feature_test"] = 10
+        self._test_save_and_reload_modified_knowledge(MetaLearnerAgent, 'knowledge_base', modify_mla_knowledge, message_bus=self.mock_bus)
+
+    def test_mla_corrupted_fallback(self):
+        # Special handling for MetaLearnerAgent's default knowledge structure
+        temp_file = self._get_temp_filepath(f"{MetaLearnerAgent.__name__}_corrupted_mla")
+        agent_dummy = MetaLearnerAgent(knowledge_file_path=temp_file, message_bus=self.mock_bus)
+        agent_dummy.save_knowledge()
+
+        with open(temp_file, 'w') as f:
+            f.write("this is not valid json")
+
+        with patch('logging.error') as mock_log_error:
+            agent = MetaLearnerAgent(knowledge_file_path=temp_file, message_bus=self.mock_bus)
+            # Compare with the structure _get_default_knowledge provides
+            expected_default_kb = agent._get_default_knowledge()
+            self.assertEqual(agent.knowledge_base, expected_default_kb,
+                             "MetaLearnerAgent should fall back to default knowledge structure on corrupted file.")
+            mock_log_error.assert_called()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/prompthelix/tests/unit/test_architect_agent.py
+++ b/prompthelix/tests/unit/test_architect_agent.py
@@ -20,7 +20,9 @@ class TestPromptArchitectAgent(unittest.TestCase):
         # For simplicity here, we assume a default mock if a test doesn't provide its own
         self.architect_config_patch = patch.dict(GLOBAL_AGENT_SETTINGS, {'PromptArchitectAgent': DEFAULT_ARCHITECT_CONFIG.copy()})
         self.mock_agent_settings = self.architect_config_patch.start()
-        self.architect = PromptArchitectAgent() # Uses mocked settings
+        # Provide knowledge_file_path=None to use default behavior (in-memory or default filename)
+        # without creating actual files during these specific unit tests unless persistence is being tested.
+        self.architect = PromptArchitectAgent(knowledge_file_path=None) # Uses mocked settings
 
     def tearDown(self):
         self.architect_config_patch.stop()

--- a/prompthelix/tests/unit/test_critic_agent.py
+++ b/prompthelix/tests/unit/test_critic_agent.py
@@ -7,7 +7,7 @@ class TestPromptCriticAgent(unittest.TestCase):
 
     def setUp(self):
         """Instantiate the PromptCriticAgent for each test."""
-        self.critic = PromptCriticAgent()
+        self.critic = PromptCriticAgent(knowledge_file_path=None)
 
     def test_agent_creation(self):
         """Test basic creation and initialization of the agent."""

--- a/prompthelix/tests/unit/test_domain_expert_agent.py
+++ b/prompthelix/tests/unit/test_domain_expert_agent.py
@@ -6,7 +6,7 @@ class TestDomainExpertAgent(unittest.TestCase):
 
     def setUp(self):
         """Instantiate the DomainExpertAgent for each test."""
-        self.expert = DomainExpertAgent()
+        self.expert = DomainExpertAgent(knowledge_file_path=None)
 
     def test_agent_creation(self):
         """Test basic creation and initialization of the agent."""

--- a/prompthelix/tests/unit/test_results_evaluator_agent.py
+++ b/prompthelix/tests/unit/test_results_evaluator_agent.py
@@ -8,7 +8,7 @@ class TestResultsEvaluatorAgent(unittest.TestCase):
 
     def setUp(self):
         """Instantiate the ResultsEvaluatorAgent for each test."""
-        self.evaluator = ResultsEvaluatorAgent()
+        self.evaluator = ResultsEvaluatorAgent(knowledge_file_path=None)
         self.test_prompt = PromptChromosome(genes=["Instruction: Test prompt"])
 
     def test_agent_creation(self):

--- a/prompthelix/tests/unit/test_style_optimizer_agent.py
+++ b/prompthelix/tests/unit/test_style_optimizer_agent.py
@@ -7,7 +7,7 @@ class TestStyleOptimizerAgent(unittest.TestCase):
 
     def setUp(self):
         """Instantiate the StyleOptimizerAgent for each test."""
-        self.optimizer = StyleOptimizerAgent()
+        self.optimizer = StyleOptimizerAgent(knowledge_file_path=None)
 
     def test_agent_creation(self):
         """Test basic creation and initialization of the agent."""


### PR DESCRIPTION
… knowledge (configurations, rules, templates, etc.) to and from JSON files. I now create a default knowledge file if one doesn't exist on startup.

I've also enhanced my internal messaging:
- I can now respond to a "ping" message, returning a "pong" to confirm connectivity.
- Message dispatching now returns the response from the recipient's handler, enabling more direct request-response patterns if needed.

I've updated my orchestrator to demonstrate these new persistence and messaging features. I've also added comprehensive unit tests for the new persistence mechanisms and messaging capabilities, and updated existing tests to be compatible with changes to my constructors.