### PR TITLE
Remove deprecated test and add CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install passlib textstat
+      - name: Run tests
+        run: python -m prompthelix.cli test

--- a/prompthelix/tests/test_api.py
+++ b/prompthelix/tests/test_api.py
@@ -13,20 +13,6 @@ class TestApi(unittest.TestCase):
         # For a minimal change, we'll keep it but acknowledge it doesn't use the shared test_client fixture.
         self.client = TestClient(app)
 
-    # def test_run_ga_endpoint(self):
-    #     """Test the /api/run-ga endpoint.
-    #     This endpoint is deprecated or its functionality changed.
-    #     The new GA endpoint /api/experiments/run-ga is tested in test_api_experiments.py.
-    #     """
-    #     # response = self.client.get("/api/run-ga")
-    #     # self.assertEqual(response.status_code, 200, f"API request failed with status {response.status_code}: {response.text}")
-    #     # try:
-    #     #     data = response.json()
-    #     # except ValueError:
-    #     #     self.fail("API response is not valid JSON.")
-    #     # self.assertIn("best_prompt", data)
-    #     # self.assertIn("fitness", data)
-    #     pass # Test removed / passing trivially
 
     def test_root_endpoint(self):
         """Test the root / endpoint."""


### PR DESCRIPTION
## Summary
- remove commented out `/api/run-ga` test
- add a GitHub Actions workflow that installs dependencies and runs `python -m prompthelix.cli test`

## Testing
- `python -m prompthelix.cli test` *(fails: 14 failed, 66 errors)*

------
https://chatgpt.com/codex/tasks/task_b_684f8916b7448321b1957537e996f069