### PR TITLE
Add Alembic setup and initial migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,9 +172,10 @@ For a manual production setup, consider the following steps:
     *   **Database Migrations**: If you are using a database like PostgreSQL, you will need to manage database schema changes. It's mentioned that the project might consider Alembic. If Alembic is integrated (check `prompthelix/alembic`), you would typically run migrations like this:
         ```bash
         # Ensure ALEMBIC_CONFIG is set or alembic.ini is configured
+        cd /path/to/PromptHelix
         alembic upgrade head
         ```
-        If Alembic is not yet fully set up, you might need to initialize it or use manual SQL scripts for schema management. The current `init_db()` is for SQLite and development.
+        Run this command whenever deploying to a new environment so your production database schema matches the models. If Alembic is not yet fully set up, you might need to initialize it or use manual SQL scripts for schema management. The current `init_db()` is for SQLite and development.
 
 4.  **Environment Variables:**
     Ensure all required environment variables (API keys, `DATABASE_URL`, etc.) are securely set in your production environment.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -9,6 +9,12 @@ from alembic import context
 # access to the values within the .ini file in use.
 config = context.config
 
+# Allow DATABASE_URL environment variable to override alembic.ini setting
+import os
+from prompthelix.database import DATABASE_URL as DEFAULT_DB_URL
+database_url = os.environ.get("DATABASE_URL", DEFAULT_DB_URL)
+config.set_main_option("sqlalchemy.url", database_url)
+
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:

--- a/alembic/versions/f0d711efe1a3_create_api_keys_table.py
+++ b/alembic/versions/f0d711efe1a3_create_api_keys_table.py
@@ -1,0 +1,38 @@
+"""create api_keys table
+
+Revision ID: f0d711efe1a3
+Revises: 334ec73d5186
+Create Date: 2025-06-16 03:03:17.730574
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f0d711efe1a3'
+down_revision: Union[str, None] = '334ec73d5186'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create api_keys table."""
+    op.create_table(
+        "api_keys",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("service_name", sa.String(), nullable=False, unique=True),
+        sa.Column("api_key", sa.String(), nullable=False),
+        sa.UniqueConstraint("service_name", name="uq_service_name"),
+    )
+    op.create_index(op.f("ix_api_keys_id"), "api_keys", ["id"], unique=False)
+    op.create_index(op.f("ix_api_keys_service_name"), "api_keys", ["service_name"], unique=True)
+
+
+def downgrade() -> None:
+    """Drop api_keys table."""
+    op.drop_index(op.f("ix_api_keys_service_name"), table_name="api_keys")
+    op.drop_index(op.f("ix_api_keys_id"), table_name="api_keys")
+    op.drop_table("api_keys")


### PR DESCRIPTION
## Summary
- configure Alembic env to read DATABASE_URL from environment
- create migration for `api_keys` table
- document running `alembic upgrade head` in README

## Testing
- `pip install -r requirements.txt`
- `pip install passlib`
- `pip install textstat`
- `pytest -q` *(fails: `ModuleNotFoundError: No module named 'textstat'` and other failures)*

------
https://chatgpt.com/codex/tasks/task_b_684f890d54808321b7c5b4d099e8053a