### PR TITLE
Persist agent knowledge under knowledge dir

### DIFF
--- a/knowledge/architect_knowledge.json
+++ b/knowledge/architect_knowledge.json
@@ -1,0 +1,17 @@
+{
+    "summary_v1": {
+        "instruction": "Summarize the following text:",
+        "context_placeholder": "[text_to_summarize]",
+        "output_format": "Concise summary."
+    },
+    "question_answering_v1": {
+        "instruction": "Answer the question based on the provided context:",
+        "context_placeholder": "Context: [context_text]\nQuestion: [question_text]",
+        "output_format": "Clear and direct answer."
+    },
+    "generic_v1": {
+        "instruction": "Perform the following task:",
+        "context_placeholder": "[details]",
+        "output_format": "As requested."
+    }
+}

--- a/knowledge/domain_expert_knowledge.json
+++ b/knowledge/domain_expert_knowledge.json
@@ -1,0 +1,96 @@
+{
+    "medical": {
+        "keywords": [
+            "patient",
+            "diagnosis",
+            "treatment",
+            "symptom",
+            "prognosis",
+            "EHR"
+        ],
+        "constraints": [
+            "Avoid speculative language.",
+            "Cite sources if possible.",
+            "Ensure patient confidentiality (simulated for prompts, e.g., use placeholders like [PATIENT_NAME])."
+        ],
+        "evaluation_tips": [
+            "Check for HIPAA compliance implications (even in simulated contexts).",
+            "Accuracy and clarity are paramount.",
+            "Verify if advice aligns with current medical guidelines (if applicable/possible)."
+        ],
+        "sample_prompt_starters": [
+            "Summarize the patient's history regarding [CONDITION]...",
+            "Outline a differential diagnosis for a patient presenting with [SYMPTOMS]...",
+            "Explain the standard treatment protocol for [DISEASE]..."
+        ]
+    },
+    "legal": {
+        "keywords": [
+            "contract",
+            "liability",
+            "precedent",
+            "jurisdiction",
+            "plaintiff",
+            "defendant"
+        ],
+        "constraints": [
+            "Do not provide legal advice (state as disclaimer if needed).",
+            "Reference specific laws or cases where appropriate (if known).",
+            "Maintain formal and precise language."
+        ],
+        "evaluation_tips": [
+            "Check for factual accuracy of legal statements.",
+            "Ensure arguments are logically sound.",
+            "Verify if interpretations are consistent with provided legal context."
+        ],
+        "sample_prompt_starters": [
+            "Analyze the provided contract clause regarding [CLAUSE_TOPIC]...",
+            "Discuss potential liabilities in a scenario where [SCENARIO_DETAILS]...",
+            "Research precedents related to [LEGAL_ISSUE]..."
+        ]
+    },
+    "coding_python": {
+        "keywords": [
+            "def",
+            "class",
+            "import",
+            "return",
+            "list comprehension",
+            "decorator",
+            "async"
+        ],
+        "constraints": [
+            "Follow PEP 8 guidelines.",
+            "Include docstrings for functions/classes.",
+            "Specify Python version if behavior differs significantly."
+        ],
+        "evaluation_tips": [
+            "Check for code execution (if possible via a sandbox).",
+            "Assess efficiency (Big O notation if applicable).",
+            "Evaluate readability and maintainability.",
+            "Ensure correctness for given problem statement."
+        ],
+        "sample_prompt_starters": [
+            "Write a Python function to [TASK_DESCRIPTION]...",
+            "Create a Python class `[CLASS_NAME]` that implements [FEATURES]...",
+            "Refactor the following Python code for better readability: [CODE_SNIPPET]..."
+        ]
+    },
+    "general_knowledge": {
+        "keywords": [
+            "explain",
+            "compare",
+            "describe",
+            "list",
+            "pros and cons"
+        ],
+        "constraints": [
+            "Provide factual information.",
+            "Cite sources if the information is obscure or critical."
+        ],
+        "evaluation_tips": [
+            "Check for accuracy.",
+            "Assess completeness and clarity of explanation."
+        ]
+    }
+}

--- a/knowledge/results_evaluator_config.json
+++ b/knowledge/results_evaluator_config.json
@@ -1,0 +1,16 @@
+{
+    "default_metrics": [
+        "relevance_placeholder",
+        "coherence_placeholder"
+    ],
+    "task_specific": {
+        "summarization": [
+            "rouge_score_placeholder",
+            "conciseness_placeholder"
+        ],
+        "code_generation": [
+            "execution_success_placeholder",
+            "code_quality_placeholder"
+        ]
+    }
+}

--- a/knowledge/style_optimizer_rules.json
+++ b/knowledge/style_optimizer_rules.json
@@ -1,0 +1,30 @@
+{
+    "formal": {
+        "replace": {
+            "don't": "do not",
+            "stuff": "items",
+            "gonna": "going to",
+            "wanna": "want to"
+        },
+        "prepend_politeness": "Please ",
+        "ensure_ending_punctuation": true
+    },
+    "casual": {
+        "replace": {
+            "do not": "don't",
+            "items": "stuff",
+            "please ": "",
+            "Please ": "",
+            "kindly ": "",
+            "Kindly ": ""
+        },
+        "remove_ending_punctuation": false
+    },
+    "instructional": {
+        "prepend_politeness": "Could you ",
+        "append_request_marker": "?",
+        "replace": {
+            "tell me": "explain"
+        }
+    }
+}

--- a/prompthelix/agents/architect.py
+++ b/prompthelix/agents/architect.py
@@ -1,7 +1,9 @@
 from prompthelix.agents.base import BaseAgent
 from prompthelix.genetics.engine import PromptChromosome
 from prompthelix.utils.llm_utils import call_llm_api
-from prompthelix.config import AGENT_SETTINGS # Import AGENT_SETTINGS
+from prompthelix.config import AGENT_SETTINGS, KNOWLEDGE_DIR
+import os
+import json
 import logging
 
 logger = logging.getLogger(__name__)
@@ -41,7 +43,15 @@ class PromptArchitectAgent(BaseAgent):
         ]
 
         # Load initial templates
-        self.knowledge_file_path = knowledge_file_path or "architect_knowledge.json"
+        if knowledge_file_path:
+            self.knowledge_file_path = (
+                knowledge_file_path
+                if os.path.isabs(knowledge_file_path)
+                else os.path.join(KNOWLEDGE_DIR, knowledge_file_path)
+            )
+        else:
+            self.knowledge_file_path = os.path.join(KNOWLEDGE_DIR, "architect_knowledge.json")
+        os.makedirs(os.path.dirname(self.knowledge_file_path), exist_ok=True)
 
         self.templates = {} # Initialize before loading
         self.load_knowledge()

--- a/prompthelix/agents/results_evaluator.py
+++ b/prompthelix/agents/results_evaluator.py
@@ -1,10 +1,11 @@
 from prompthelix.agents.base import BaseAgent
 from prompthelix.genetics.engine import PromptChromosome
 from prompthelix.utils.llm_utils import call_llm_api
-import random # For placeholder metric generation
-import json # For parsing LLM responses
+import random  # For placeholder metric generation
+import json  # For parsing LLM responses
 import logging
-from prompthelix.config import AGENT_SETTINGS # Import AGENT_SETTINGS
+import os
+from prompthelix.config import AGENT_SETTINGS, KNOWLEDGE_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +36,15 @@ class ResultsEvaluatorAgent(BaseAgent):
         self.fitness_score_weights = agent_config.get("fitness_score_weights", DEFAULT_FITNESS_WEIGHTS)
         logger.info(f"Agent '{self.agent_id}' initialized with LLM provider: {self.llm_provider}, Evaluation model: {self.evaluation_llm_model}")
 
-        self.knowledge_file_path = knowledge_file_path or "results_evaluator_config.json"
+        if knowledge_file_path:
+            self.knowledge_file_path = (
+                knowledge_file_path
+                if os.path.isabs(knowledge_file_path)
+                else os.path.join(KNOWLEDGE_DIR, knowledge_file_path)
+            )
+        else:
+            self.knowledge_file_path = os.path.join(KNOWLEDGE_DIR, "results_evaluator_config.json")
+        os.makedirs(os.path.dirname(self.knowledge_file_path), exist_ok=True)
 
         self.evaluation_metrics_config = {} # Initialize before loading
         self.load_knowledge()

--- a/prompthelix/agents/style_optimizer.py
+++ b/prompthelix/agents/style_optimizer.py
@@ -1,9 +1,10 @@
 from prompthelix.agents.base import BaseAgent
 from prompthelix.genetics.engine import PromptChromosome
 from prompthelix.utils.llm_utils import call_llm_api
-from prompthelix.config import AGENT_SETTINGS # Import AGENT_SETTINGS
-import json # For parsing LLM response
+from prompthelix.config import AGENT_SETTINGS, KNOWLEDGE_DIR
+import json  # For parsing LLM response
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +18,7 @@ class StyleOptimizerAgent(BaseAgent):
     Refines prompts to enhance their style, tone, clarity, and persuasiveness,
     often based on specific target audience or desired communication effect.
     """
-    def __init__(self, message_bus=None):
+    def __init__(self, message_bus=None, knowledge_file_path=None):
         """
         Initializes the StyleOptimizerAgent.
         Loads style transformation rules or lexicons and agent configuration.
@@ -32,9 +33,15 @@ class StyleOptimizerAgent(BaseAgent):
         self.llm_model = agent_config.get("default_llm_model", FALLBACK_LLM_MODEL)
         logger.info(f"Agent '{self.agent_id}' initialized with LLM provider: {self.llm_provider} and model: {self.llm_model}")
 
-        self.knowledge_file_path = knowledge_file_path
-        if self.knowledge_file_path is None:
-            self.knowledge_file_path = "style_optimizer_rules.json"
+        if knowledge_file_path:
+            self.knowledge_file_path = (
+                knowledge_file_path
+                if os.path.isabs(knowledge_file_path)
+                else os.path.join(KNOWLEDGE_DIR, knowledge_file_path)
+            )
+        else:
+            self.knowledge_file_path = os.path.join(KNOWLEDGE_DIR, "style_optimizer_rules.json")
+        os.makedirs(os.path.dirname(self.knowledge_file_path), exist_ok=True)
 
         self.style_rules = {} # Initialize before loading
         self.load_knowledge()


### PR DESCRIPTION
## Summary
- configure PromptArchitectAgent, DomainExpertAgent, ResultsEvaluatorAgent and StyleOptimizerAgent to store their knowledge in `knowledge/`
- generate default knowledge JSON files for these agents

## Testing
- `pytest prompthelix/tests/unit/test_style_optimizer_agent.py::TestStyleOptimizerAgent::test_agent_creation -q`
- `pytest prompthelix/tests/unit/test_domain_expert_agent.py::TestDomainExpertAgent::test_agent_creation -q`
- `pytest prompthelix/tests/unit/test_results_evaluator_agent.py::TestResultsEvaluatorAgent::test_agent_creation -q`
- `pytest prompthelix/tests/unit/test_architect_agent.py::TestPromptArchitectAgent::test_process_request_full_fallback_due_to_llm_system_down -q` *(fails: 'ethics' not found)*
- `pytest prompthelix/tests/unit/test_meta_learner_agent.py::TestMetaLearnerAgent::test_agent_creation_and_initial_kb_structure -q` *(fails: NameError: MessageBus not defined)*

------
https://chatgpt.com/codex/tasks/task_b_684f89014d0483219ecff676a49713d2