### PR TITLE
Implement async message bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ AI prompts through innovative techniques inspired by genetic algorithms and mult
 *   API for programmatic access and integration
 *   User interface for managing and experimenting with prompts (basic HTML interface available)
 
+### Inter-Agent Messaging
+
+Agents communicate via an asynchronous message bus. Each agent can subscribe to
+specific message types and react when messages are broadcast. For example, the
+`ResultsEvaluatorAgent` broadcasts an `evaluation_result` message after scoring a
+prompt. The `MetaLearnerAgent` subscribes to both `evaluation_result` and
+`critique_result` messages so it can update its knowledge base whenever new
+feedback is produced.
+
 ## Getting Started
 
 ### Prerequisites

--- a/prompthelix/agents/critic.py
+++ b/prompthelix/agents/critic.py
@@ -2,8 +2,9 @@ from prompthelix.agents.base import BaseAgent
 from prompthelix.genetics.engine import PromptChromosome
 from prompthelix.utils.llm_utils import call_llm_api
 from prompthelix.config import AGENT_SETTINGS
-from prompthelix.evaluation import metrics as prompt_metrics # Import new metrics
+from prompthelix.evaluation import metrics as prompt_metrics  # Import new metrics
 import logging
+import asyncio
 
 logger = logging.getLogger(__name__)
 
@@ -371,5 +372,11 @@ Best Practice Note: Consider specifying the desired output format.
             "metric_details": programmatic_metric_details # Include the new scores for transparency
         }
         logger.info(f"Agent '{self.agent_id}': Critique result - Score={critique_score}, Total Feedback Points#={len(feedback_points)}, Programmatic Scores={programmatic_metric_details}")
+        if self.message_bus:
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(self.message_bus.broadcast_message("critique_result", result, sender_id=self.agent_id))
+            except RuntimeError:
+                asyncio.run(self.message_bus.broadcast_message("critique_result", result, sender_id=self.agent_id))
         return result
 

--- a/prompthelix/agents/meta_learner.py
+++ b/prompthelix/agents/meta_learner.py
@@ -51,6 +51,11 @@ class MetaLearnerAgent(BaseAgent):
 
         self.persist_on_update = agent_config.get("persist_knowledge_on_update", PERSIST_ON_UPDATE_DEFAULT)
 
+        # Subscribe to evaluation and critique results if a message bus is available
+        if self.message_bus:
+            self.subscribe_to("evaluation_result")
+            self.subscribe_to("critique_result")
+
         # Default structure for knowledge_base
         self._default_knowledge_base_structure = {
             "successful_prompt_features": [], # Features of prompts that led to high fitness_score

--- a/prompthelix/agents/results_evaluator.py
+++ b/prompthelix/agents/results_evaluator.py
@@ -5,6 +5,7 @@ import random  # For placeholder metric generation
 import json  # For parsing LLM responses
 import logging
 import os
+import asyncio
 from prompthelix.config import AGENT_SETTINGS, KNOWLEDGE_DIR
 
 logger = logging.getLogger(__name__)
@@ -382,9 +383,20 @@ Example:
         fitness_score = max(0.0, min(1.0, fitness_score))
 
         logger.info(f"Agent '{self.agent_id}': Evaluation complete. Fitness: {fitness_score:.4f}, Metrics: {metrics}, Evaluation Process Errors: {len(content_errors)}, Constraint Violations: {len(constraint_feedback.get('errors',[]))}")
-        return {
+        result = {
             "fitness_score": fitness_score,
             "detailed_metrics": metrics,
-            "error_analysis": errors
+            "error_analysis": errors,
+            "prompt_chromosome": prompt_chromosome,
         }
+
+        # Broadcast the evaluation result if a bus is available
+        if self.message_bus:
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(self.message_bus.broadcast_message("evaluation_result", result, sender_id=self.agent_id))
+            except RuntimeError:
+                asyncio.run(self.message_bus.broadcast_message("evaluation_result", result, sender_id=self.agent_id))
+
+        return result
 

--- a/prompthelix/docs/README.md
+++ b/prompthelix/docs/README.md
@@ -50,6 +50,14 @@ The PromptHelix system is designed around a collection of specialized AI agents 
 ### Agent Functionality Notes
 The current implementations of these agents are functional placeholders. They utilize mock data (e.g., for templates, critique rules, style rules, domain knowledge) and simplified internal logic. This approach is intended to establish the foundational framework of the multi-agent system and demonstrate the intended interactions and data flows. Future development will involve replacing mock data with configurable sources and implementing more sophisticated algorithms and machine learning models within each agent.
 
+### Message Flow
+
+Agents interact through an asynchronous message bus. Agents subscribe to message
+types they care about and broadcast results for others to consume. The
+`ResultsEvaluatorAgent` and `PromptCriticAgent` broadcast `evaluation_result` and
+`critique_result` messages respectively. The `MetaLearnerAgent` listens for these
+messages and updates its knowledge base whenever new feedback arrives.
+
 ## Testing
 
 Unit tests for the core placeholder functionalities of each agent and the genetic algorithm components are located in the `prompthelix/tests/unit/` directory. Each component has its own test file (e.g., `test_architect_agent.py`, `test_genetic_operators.py`, etc.) that verifies its basic operations.

--- a/prompthelix/message_bus.py
+++ b/prompthelix/message_bus.py
@@ -1,4 +1,6 @@
 import logging
+import asyncio
+import inspect
 
 # Configure basic logging for the message bus
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -10,6 +12,10 @@ class MessageBus:
     """
     def __init__(self):
         self._registry = {}
+        self._subscriptions = {}
+        self._queue = asyncio.Queue()
+        self._task = None
+        self._running = False
         logger.info("MessageBus initialized.")
 
     def register(self, agent_id: str, agent_instance):
@@ -37,6 +43,62 @@ class MessageBus:
             logger.info(f"Agent '{agent_id}' unregistered from the message bus.")
         else:
             logger.warning(f"Attempted to unregister agent ID '{agent_id}', which was not found.")
+
+    def subscribe(self, agent_id: str, message_type: str):
+        """Subscribes an agent to a specific message type for broadcast."""
+        if agent_id not in self._registry:
+            logger.error(f"Cannot subscribe unknown agent '{agent_id}'.")
+            return
+        self._subscriptions.setdefault(message_type, set()).add(agent_id)
+        logger.info(f"Agent '{agent_id}' subscribed to '{message_type}' messages.")
+
+    def unsubscribe(self, agent_id: str, message_type: str):
+        """Removes an agent subscription for a message type."""
+        if message_type in self._subscriptions:
+            self._subscriptions[message_type].discard(agent_id)
+            logger.info(f"Agent '{agent_id}' unsubscribed from '{message_type}' messages.")
+
+    def start(self):
+        """Starts the async queue processing loop if not already running."""
+        if not self._running:
+            self._running = True
+            self._task = asyncio.create_task(self._process_queue())
+
+    async def stop(self):
+        """Stops the queue processing loop."""
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+    async def _deliver(self, agent, message):
+        """Internal helper to deliver a message to an agent, awaiting if coroutine."""
+        if hasattr(agent, 'receive_message') and callable(agent.receive_message):
+            if inspect.iscoroutinefunction(agent.receive_message):
+                await agent.receive_message(message)
+            else:
+                agent.receive_message(message)
+        else:
+            logger.error(f"Agent '{getattr(agent, 'agent_id', 'unknown')}' lacks a callable 'receive_message' method.")
+
+    async def _process_queue(self):
+        """Background task that processes broadcast messages."""
+        while self._running:
+            message = await self._queue.get()
+            msg_type = message.get('message_type')
+            recipients = self._subscriptions.get(msg_type, set()).copy()
+            for agent_id in recipients:
+                agent = self._registry.get(agent_id)
+                if agent:
+                    try:
+                        await self._deliver(agent, message)
+                    except Exception as e:
+                        logger.error(f"Error delivering broadcast to agent '{agent_id}': {e}", exc_info=True)
+                else:
+                    logger.warning(f"Subscribed agent '{agent_id}' not registered. Skipping.")
 
     def dispatch_message(self, message: dict):
         """
@@ -79,6 +141,17 @@ class MessageBus:
             logger.warning(f"Recipient agent '{recipient_id}' not found in registry. Message from '{sender_id}' of type '{message_type}' could not be delivered.")
             return {"status": "error", "error": f"Recipient agent '{recipient_id}' not found."}
 
+    async def broadcast_message(self, message_type: str, payload: dict, sender_id: str = "system"):
+        """Places a broadcast message onto the internal queue."""
+        message = {
+            "sender_id": sender_id,
+            "recipient_id": None,
+            "message_type": message_type,
+            "payload": payload,
+        }
+        await self._queue.put(message)
+        self.start()
+
 if __name__ == '__main__':
     # Example Usage (simple test within the file)
     class MockAgent:
@@ -118,6 +191,15 @@ if __name__ == '__main__':
     # Test unregister
     bus.unregister("AgentA")
     agent_B.send_message(recipient_id="AgentA", message_type="farewell", payload={"data": "Goodbye from B"})
+
+    # Broadcast demonstration
+    async def demo_broadcast():
+        bus.subscribe(agent_B.agent_id, "broadcast_test")
+        await bus.broadcast_message("broadcast_test", {"info": "Hello subscribers"}, sender_id="AgentA")
+        await asyncio.sleep(0.1)
+        await bus.stop()
+
+    asyncio.run(demo_broadcast())
 
     # Test invalid message
     bus.dispatch_message({"sender_id": "system", "payload": "test"})


### PR DESCRIPTION
## Summary
- support async broadcast & subscriptions in `message_bus`
- expose `broadcast_message` and `subscribe_to` from `BaseAgent`
- broadcast results from critic and results evaluator agents
- MetaLearner subscribes to evaluation & critique messages
- document new messaging flow

## Testing
- `pip install passlib`
- `pip install textstat`
- `pytest -q` *(fails: ModuleNotFoundError and network calls blocked)*

------
https://chatgpt.com/codex/tasks/task_b_684f8f7551088321853163e7b7327833