### PR TITLE
Fix critic agent init signature

### DIFF
--- a/prompthelix/agents/critic.py
+++ b/prompthelix/agents/critic.py
@@ -19,13 +19,16 @@ class PromptCriticAgent(BaseAgent):
     and adherence to best practices, without necessarily executing them.
     It acts as a "static analyzer" for prompts.
     """
-    def __init__(self, message_bus=None):
+    def __init__(self, message_bus=None, knowledge_file_path=None):
         """
         Initializes the PromptCriticAgent.
         Loads critique rules or heuristics and agent configuration.
 
         Args:
             message_bus (object, optional): The message bus for inter-agent communication.
+            knowledge_file_path (str, optional): Path to the JSON file storing
+                critique rules. Defaults to "critic_rules.json" if not
+                provided.
         """
         super().__init__(agent_id=self.agent_id, message_bus=message_bus)
 
@@ -34,9 +37,7 @@ class PromptCriticAgent(BaseAgent):
         self.llm_model = agent_config.get("default_llm_model", FALLBACK_LLM_MODEL)
         logger.info(f"Agent '{self.agent_id}' initialized with LLM provider: {self.llm_provider} and model: {self.llm_model}")
 
-        self.knowledge_file_path = knowledge_file_path
-        if self.knowledge_file_path is None:
-            self.knowledge_file_path = "critic_rules.json"
+        self.knowledge_file_path = knowledge_file_path or "critic_rules.json"
 
         self.critique_rules = [] # Initialize before loading
         self.load_knowledge()

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+# This space intentionally left blank.

--- a/tests/unit/test_critic_agent.py
+++ b/tests/unit/test_critic_agent.py
@@ -1,0 +1,17 @@
+import os
+import tempfile
+import unittest
+
+from prompthelix.agents.critic import PromptCriticAgent
+
+class TestPromptCriticAgentCustomFile(unittest.TestCase):
+    def test_initialization_with_custom_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            custom_path = os.path.join(tmpdir, "custom_rules.json")
+            agent = PromptCriticAgent(knowledge_file_path=custom_path)
+            self.assertEqual(agent.knowledge_file_path, custom_path)
+            self.assertTrue(os.path.exists(custom_path))
+            self.assertTrue(agent.critique_rules)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- update `PromptCriticAgent.__init__` to accept `knowledge_file_path`
- document new parameter
- provide a small unit test covering custom file initialization

## Testing
- `pytest tests/unit/test_critic_agent.py -q`

------
https://chatgpt.com/codex/tasks/task_b_684f8f81b7348321aa2d836fecaa27c9