### PR TITLE
Fix OpenAI import fallback

### DIFF
--- a/prompthelix/utils/llm_utils.py
+++ b/prompthelix/utils/llm_utils.py
@@ -10,7 +10,21 @@ from prompthelix.config import (
 from typing import Optional  # Added for Optional type hint
 
 import openai
-from openai import OpenAIError, APIError as OpenAPIApiError, RateLimitError as OpenAIRateLimitError, AuthenticationError as OpenAIAuthenticationError, APIConnectionError as OpenAIAPIConnectionError, InvalidRequestError as OpenAIInvalidRequestError
+from openai import (
+    OpenAIError,
+    APIError as OpenAPIApiError,
+    RateLimitError as OpenAIRateLimitError,
+    AuthenticationError as OpenAIAuthenticationError,
+    APIConnectionError as OpenAIAPIConnectionError,
+)
+
+# The InvalidRequestError was renamed to BadRequestError in newer versions of
+# the OpenAI SDK. Try the new name first and fall back to the old one so the
+# code works with both old and new SDK releases.
+try:  # pragma: no cover - import resolution depends on installed SDK version
+    from openai import InvalidRequestError as OpenAIInvalidRequestError
+except Exception:  # pragma: no cover - executed when InvalidRequestError is missing
+    from openai import BadRequestError as OpenAIInvalidRequestError
 
 import anthropic
 # Renamed Anthropic client import to avoid conflict with the error type


### PR DESCRIPTION
## Summary
- handle InvalidRequestError/BadRequestError based on SDK version
- update tests for new OpenAI and Anthropic error signatures

## Testing
- `pytest -q` *(fails: OperationalError: no such table: users)*

------
https://chatgpt.com/codex/tasks/task_b_684fc1aad698832186008865f796994e