### PR TITLE
Enable loading of .env file

### DIFF
--- a/prompthelix/config.py
+++ b/prompthelix/config.py
@@ -5,16 +5,18 @@ This file defines the settings for the application, including API keys,
 database URLs, and other operational parameters. It supports loading
 configurations from environment variables and potentially .env files.
 """
+# Load environment variables from a .env file if present
 import os
 from sqlalchemy.orm import Session
 from typing import Optional
 from prompthelix.api import crud
+from dotenv import load_dotenv
 # from pydantic import BaseSettings # Uncomment if Pydantic is used for settings management
 
-# Consider using a library like python-dotenv to load .env files
-# Example:
-# from dotenv import load_dotenv
-# load_dotenv()
+# Automatically load variables from a .env file in the project root.
+# This allows users to define their API keys and other configuration
+# settings in a local .env file without exporting them manually.
+load_dotenv()
 
 # IMPORTANT: LLM API Key Configuration
 # The system requires API keys for the Large Language Models it interfaces with.

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ redis
 openai
 anthropic
 google-generativeai
+python-dotenv


### PR DESCRIPTION
## Summary
- install `python-dotenv`
- load `.env` in config on import

## Testing
- `pip install -r requirements.txt`
- `python -m prompthelix.cli test` *(fails: some tests errored)*

------
https://chatgpt.com/codex/tasks/task_b_684fdc6f79f4832195ede483f8f95530