### PR TITLE
Fix: Ensure .env OPENAI_API_KEY overrides and add debug logging

### DIFF
--- a/prompthelix/config.py
+++ b/prompthelix/config.py
@@ -7,16 +7,19 @@ configurations from environment variables and potentially .env files.
 """
 # Load environment variables from a .env file if present
 import os
+import logging
 from sqlalchemy.orm import Session
 from typing import Optional
 from prompthelix.api import crud
 from dotenv import load_dotenv
 # from pydantic import BaseSettings # Uncomment if Pydantic is used for settings management
 
+logger = logging.getLogger(__name__)
+
 # Automatically load variables from a .env file in the project root.
 # This allows users to define their API keys and other configuration
 # settings in a local .env file without exporting them manually.
-load_dotenv()
+load_dotenv(override=True)
 
 # IMPORTANT: LLM API Key Configuration
 # The system requires API keys for the Large Language Models it interfaces with.
@@ -71,6 +74,7 @@ class Settings:
 
 # Instantiate the settings
 settings = Settings()
+logger.info(f"Loaded OPENAI_API_KEY: {settings.OPENAI_API_KEY[:5]}...{settings.OPENAI_API_KEY[-4:] if settings.OPENAI_API_KEY and len(settings.OPENAI_API_KEY) > 9 else 'INVALID_OR_SHORT_KEY'}")
 
 # Example of how to access a setting:
 # print(settings.DATABASE_URL)


### PR DESCRIPTION
I modified `prompthelix/config.py` to:
1. Change `load_dotenv()` to `load_dotenv(override=True)`. This ensures that environment variables defined in the .env file take precedence over any system-level environment variables with the same name. This is particularly important for `OPENAI_API_KEY`.
2. Add an informational log statement immediately after the Settings object is instantiated. This log displays a masked version of the loaded `OPENAI_API_KEY` (first 5 and last 4 characters) to help you verify that the correct key is being picked up by the application, which can aid in diagnosing API key related issues.

These changes aim to resolve issues where an incorrect or quota-exhausted OpenAI API key might be used despite a valid key being present in the .env file.