### PR TITLE
Fix missing config utils module

### DIFF
--- a/prompthelix/config.py
+++ b/prompthelix/config.py
@@ -74,7 +74,12 @@ class Settings:
 
 # Instantiate the settings
 settings = Settings()
-logger.info(f"Loaded OPENAI_API_KEY: {settings.OPENAI_API_KEY[:5]}...{settings.OPENAI_API_KEY[-4:] if settings.OPENAI_API_KEY and len(settings.OPENAI_API_KEY) > 9 else 'INVALID_OR_SHORT_KEY'}")
+_openai_key = settings.OPENAI_API_KEY
+if _openai_key:
+    display_key = f"{_openai_key[:5]}...{_openai_key[-4:] if len(_openai_key) > 9 else ''}"
+else:
+    display_key = "NOT_SET"
+logger.info(f"Loaded OPENAI_API_KEY: {display_key}")
 
 # Example of how to access a setting:
 # print(settings.DATABASE_URL)

--- a/prompthelix/utils/__init__.py
+++ b/prompthelix/utils/__init__.py
@@ -1,1 +1,5 @@
-# This space intentionally left blank.
+"""Utility helper functions for PromptHelix."""
+
+from .config_utils import update_settings
+
+__all__ = ["update_settings"]

--- a/prompthelix/utils/config_utils.py
+++ b/prompthelix/utils/config_utils.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, MutableMapping
+
+
+def update_settings(base: MutableMapping[str, Any], overrides: Mapping[str, Any] | None) -> MutableMapping[str, Any]:
+    """Recursively merge override values into ``base``.
+
+    Parameters
+    ----------
+    base:
+        Original settings dictionary to update.
+    overrides:
+        Dictionary with values that should override those in ``base``.
+
+    Returns
+    -------
+    MutableMapping[str, Any]
+        The updated ``base`` dictionary.
+    """
+    if not overrides:
+        return base
+
+    for key, value in overrides.items():
+        if (
+            key in base
+            and isinstance(base[key], Mapping)
+            and isinstance(value, Mapping)
+        ):
+            update_settings(base[key], value)
+        else:
+            base[key] = value
+    return base


### PR DESCRIPTION
## Summary
- implement a `config_utils.update_settings` helper for merging config dicts
- expose `update_settings` in `prompthelix.utils`
- avoid `None` indexing when logging the OpenAI API key

## Testing
- `pip install -r requirements.txt`
- `pip install passlib textstat`
- `python -m prompthelix.cli test` *(fails: FitnessEvaluator.__init__ missing argument, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68503e38789c83218fd68098ba3f1a73