### PR TITLE
Fix multiple UI-related errors and improve error reporting.

### DIFF
--- a/prompthelix/main.py
+++ b/prompthelix/main.py
@@ -2,6 +2,9 @@
 Main application file for the PromptHelix API.
 Initializes the FastAPI application and includes the root endpoint.
 """
+import traceback
+from fastapi import Request
+from fastapi.responses import JSONResponse
 from fastapi import FastAPI
 # from fastapi.templating import Jinja2Templates # Moved to templating.py
 from fastapi.staticfiles import StaticFiles
@@ -22,6 +25,48 @@ app = FastAPI()
 app.mount("/static", StaticFiles(directory="prompthelix/static"), name="static")
 
 
+# Add this before including routers
+@app.exception_handler(Exception)
+async def generic_exception_handler(request: Request, exc: Exception):
+    # In a production environment, you would typically check a DEBUG flag
+    # (e.g., from settings) to decide whether to include the traceback.
+    # For example:
+    # from prompthelix.config import settings
+    # if settings.DEBUG:
+    #     return JSONResponse(
+    #         status_code=500,
+    #         content={
+    #             "message": "An unexpected error occurred.",
+    #             "detail": str(exc),
+    #             "traceback": traceback.format_exc(),
+    #         },
+    #     )
+    # else:
+    #     # Log the exception for server-side review
+    #     # logger.error(f"Unhandled exception: {exc}", exc_info=True)
+    #     return JSONResponse(
+    #         status_code=500,
+    #         content={
+    #             "message": "An unexpected server error occurred.",
+    #             "detail": "Please contact support or try again later.",
+    #         },
+    #     )
+
+    # For now, always include traceback as per user request for easier debugging in current context.
+    # Consider adding a DEBUG flag check for production.
+    print(f"Unhandled exception: {exc}") # Basic logging
+    traceback.print_exc() # Print traceback to server console
+
+    return JSONResponse(
+        status_code=500,
+        content={
+            "message": "An unexpected error occurred.",
+            "detail": str(exc),
+            "traceback": traceback.format_exc(),
+        },
+    )
+
+
 # TODO: Implement WebSocket support for real-time communication (future feature).
 # TODO: Implement robust authentication and authorization mechanisms (future feature).
 # TODO: Implement rate limiting to protect the API (future feature).
@@ -33,6 +78,7 @@ async def root():
     Returns a welcome message.
     """
     return {"message": "Welcome to PromptHelix API"}
+
 
 # Include API routes
 app.include_router(api_routes.router)

--- a/prompthelix/templates/llm_playground.html
+++ b/prompthelix/templates/llm_playground.html
@@ -92,7 +92,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
         try {
             // Determine the base URL for the API call
-            // const apiBaseUrl = '{{ request.url_for("api_base") }}'; // If you have a base API route
+            // const apiBaseUrl = ''; // If you have a base API route
             // For now, constructing relative path, assuming API is served from same domain/port.
             // The API route for testing prompts is assumed to be '/api/llm/test_prompt'
             // If the API route has a name like 'test_llm_prompt_api', use:
@@ -139,7 +139,12 @@ document.addEventListener('DOMContentLoaded', function () {
                 responseStatusDiv.textContent = errorMessage;
                 responseStatusDiv.className = 'text-sm text-red-500 mb-2'; // Error styling
                 // Displaying the full error object might be useful for debugging
-                responseContentPre.textContent = JSON.stringify(responseData, null, 2);
+                let fullErrorText = JSON.stringify(responseData, null, 2);
+                if (responseData.traceback) {
+                    // Prepend traceback if available
+                    fullErrorText = "Server Traceback:\n" + responseData.traceback + "\n\nFull JSON Response:\n" + fullErrorText;
+                }
+                responseContentPre.textContent = fullErrorText;
             }
         } catch (error) {
             console.error('Playground Fetch Error:', error);

--- a/prompthelix/ui_routes.py
+++ b/prompthelix/ui_routes.py
@@ -96,7 +96,7 @@ async def create_prompt_ui_submit(
     # Redirect to the new prompt's detail page
     # Use request.url_for to get the URL for the named route
     message = f"Prompt '{db_prompt.name}' created successfully."
-    redirect_url = request.url_for('view_prompt_ui', prompt_id=db_prompt.id) + f"?message={message}"
+    redirect_url = str(request.url_for('view_prompt_ui', prompt_id=db_prompt.id)) + f"?message={message}"
     return RedirectResponse(url=redirect_url, status_code=303)
 
 
@@ -138,7 +138,7 @@ async def run_experiment_ui_submit(
 
     api_experiment_url = request.url_for('api_run_ga_experiment') # Needs name in API route
 
-    async with httpx.AsyncClient(app=request.app, base_url=request.base_url) as client:
+    async with httpx.AsyncClient(app=request.app, base_url=str(request.base_url)) as client:
         try:
             response = await client.post(api_experiment_url, json=ga_params.model_dump(exclude_none=True))
             response.raise_for_status()  # Raises an exception for 4XX/5XX responses


### PR DESCRIPTION
This commit addresses three distinct errors causing 500 Internal Server Errors in the UI:
1.  Resolves a `starlette.routing.NoMatchFound` error in `llm_playground.html` by removing an erroneous Jinja2 `url_for("api_base")` call from a JavaScript comment.
2.  Fixes a `TypeError` in `ui_routes.py` (`create_prompt_ui_submit`) by explicitly converting a `starlette.datastructures.URL` object to a string before concatenating it with a query string.
3.  Corrects a `TypeError` in `ui_routes.py` (`run_experiment_ui_submit`) by ensuring the `base_url` passed to `httpx.AsyncClient` is a string, not a `starlette.datastructures.URL` object.

Additionally, to aid in debugging as you requested:
- A generic exception handler has been added to `main.py`. This handler catches unhandled exceptions and returns a JSON response containing the full traceback.
- The LLM playground (`llm_playground.html`) JavaScript has been updated to detect and display this traceback information within the UI, providing better visibility into server-side issues.