### PR TITLE
Fix: Correct route name for LLM playground API call

### DIFF
--- a/prompthelix/templates/llm_playground.html
+++ b/prompthelix/templates/llm_playground.html
@@ -99,10 +99,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
             // const apiUrl = ""; // Formerly: (a url_for call for 'test_llm_prompt_api' was here)
 
-            // const apiUrl = ""; // Formerly: "{{ request.url_for('test_llm_prompt_api') }}"
+            const apiUrl = "{{ request.url_for('test_llm_prompt') }}";
 
             // For this subtask, using the literal path as specified.
-            const apiUrl = '/api/llm/test_prompt';
 
 
             const response = await fetch(apiUrl, {


### PR DESCRIPTION
The llm_playground.html template was attempting to use `request.url_for` with an incorrect route name "test_llm_prompt_api", which caused a "No route exists" error.

This commit updates the template to use the correct route name "test_llm_prompt", which is defined in `prompthelix/api/routes.py` for the `/api/llm/test_prompt` endpoint.

This ensures the LLM playground can correctly resolve the API URL and make requests to test LLM prompts.