### PR TITLE
I've made some changes to address a PicklingError in the `test_run_ga…

### DIFF
--- a/prompthelix/cli.py
+++ b/prompthelix/cli.py
@@ -51,6 +51,7 @@ def main_cli():
     run_parser.add_argument("--task-description", type=str, help="Detailed task description for the GA.")
     run_parser.add_argument("--keywords", type=str, nargs='+', help="Keywords for the GA.")
     run_parser.add_argument("--num-generations", type=int, help="Number of generations for the GA.")
+    run_parser.add_argument("--parallel-workers", type=int, default=None, help="Number of parallel workers for fitness evaluation. 1 for serial execution. Default: None (uses os.cpu_count() or similar).")
     run_parser.add_argument("--population-size", type=int, help="Population size for the GA.")
     run_parser.add_argument("--elitism-count", type=int, help="Elitism count for the GA.")
     run_parser.add_argument("--output-file", type=str, help="File path to save the best prompt.")
@@ -212,6 +213,7 @@ def main_cli():
                     initial_prompt_str=initial_prompt_str,
                     agent_settings_override=agent_settings_override,
                     llm_settings_override=llm_settings_override,
+                    parallel_workers=args.parallel_workers, # Pass the new argument
                     return_best=True
                 )
 

--- a/prompthelix/orchestrator.py
+++ b/prompthelix/orchestrator.py
@@ -31,6 +31,7 @@ def main_ga_loop(
     initial_prompt_str: Optional[str] = None,
     agent_settings_override: Optional[Dict] = None,
     llm_settings_override: Optional[Dict] = None,
+    parallel_workers: Optional[int] = None, # New parameter
     return_best: bool = True,
     population_path: Optional[str] = None
 ):
@@ -61,6 +62,10 @@ def main_ga_loop(
         logger.info(f"Agent Settings Override provided: {agent_settings_override}")
     if llm_settings_override:
         logger.info(f"LLM Settings Override provided: {llm_settings_override}")
+    if parallel_workers is not None:
+        logger.info(f"Parallel Workers specified: {parallel_workers}")
+    else:
+        logger.info("Parallel Workers: Using default (None).")
 
     # 0. Instantiate Message Bus
     logger.debug("Initializing Message Bus...")
@@ -133,12 +138,14 @@ def main_ga_loop(
         prompt_architect_agent=prompt_architect, # Architect is used for initial prompt generation
         population_size=population_size,
         elitism_count=elitism_count,
+        parallel_workers=parallel_workers, # Pass the new parameter
         population_path=population_path
         # TODO: Pass agent_settings_override or specific agent configs if PopulationManager
         # is responsible for creating/configuring more agents during its operations.
         # For now, agents are configured above.
     )
     # TODO: PopulationManager needs to be updated to accept and use initial_prompt_str.
+    #       Actually, initial_prompt_str is passed to initialize_population and also handled by PopulationManager's __init__
     logger.debug("GA components initialized.")
 
     # 3. Use GA Parameters (already logged)
@@ -403,6 +410,7 @@ if __name__ == "__main__":
         population_size=example_pop,
         elitism_count=example_elitism,
         execution_mode=ExecutionMode.TEST, # Added for the example call
+        parallel_workers=None, # Example: use default for this specific call
         return_best=True
     )
     if best_chromosome:

--- a/prompthelix/tests/test_cli.py
+++ b/prompthelix/tests/test_cli.py
@@ -10,7 +10,18 @@ class TestCli(unittest.TestCase):
         # Construct the command to run the CLI module
         # Assumes the tests are run from the root of the project or a similar context
         # where 'python -m prompthelix.cli' is valid.
-        command = [sys.executable, "-m", "prompthelix.cli", "run"]
+        command = [
+            sys.executable,
+            "-m",
+            "prompthelix.cli",
+            "run",
+            "--parallel-workers",
+            "1",  # Force serial execution for this test
+            # Using default GA parameters for this test, e.g. num_generations=2, pop_size=5
+            # Ensure execution mode is TEST to avoid real LLM calls if not mocked
+            "--execution-mode",
+            "TEST"
+        ]
 
         try:
             # Execute the command

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ openai
 anthropic
 google-generativeai
 python-dotenv
+passlib==1.7.4
+textstat==0.7.3


### PR DESCRIPTION
…_command`.

This error was happening when running `python -m prompthelix.cli test`. It was caused by the Genetic Algorithm's PopulationManager trying to use multiprocessing for fitness evaluation, but the mock objects in the test setup weren't picklable.

Here's how I fixed it:

1.  I updated the `PopulationManager` so it can evaluate fitness serially if `parallel_workers` is set to 1.
2.  I added a `--parallel-workers` option to the `run ga` command. This lets you control how many workers the PopulationManager uses.
3.  I modified `test_run_ga_command` in `test_cli.py` to use `--parallel-workers 1` and `--execution-mode TEST`. This makes sure this particular integration test runs the GA serially, which avoids the pickling issue with mock objects.

Although this fixes the PicklingError for `test_run_ga_command`, the test now fails because of a different AssertionError. Also, other unit tests that check parallel population evolution with mocks might still show PicklingErrors, as they weren't part of this specific fix.