### PR TITLE
Add UI auth dependency

### DIFF
--- a/prompthelix/message_bus.py
+++ b/prompthelix/message_bus.py
@@ -78,29 +78,6 @@ class MessageBus:
     def register(self, agent_id: str, agent_instance):
         """
         Registers an agent instance with the message bus.
-        try:
-            db = self.db_session_factory()
-            log_entry = ConversationLog(
-                session_id=session_id,
-                sender_id=sender_id,
-                recipient_id=recipient_id,
-                message_type=message_type,
-                content=json.dumps(content_payload)
-            )
-            db.add(log_entry)
-            db.commit()
-            logger.debug(f"Message from {sender_id} to {recipient_id} logged to DB. Session: {session_id}, Type: {message_type}")
-        except Exception as e:
-            logger.error(f"Failed to log message to DB: {e}", exc_info=True)
-            if db:
-                db.rollback()
-        finally:
-            if db:
-                db.close()
-
-    def register(self, agent_id: str, agent_instance):
-        """
-        Registers an agent instance with the message bus.
 
         Args:
             agent_id (str): The unique identifier for the agent.

--- a/prompthelix/orchestrator.py
+++ b/prompthelix/orchestrator.py
@@ -2,7 +2,9 @@ from prompthelix.message_bus import MessageBus
 import logging
 import time # Added
 from prompthelix.database import SessionLocal # Added
-from prompthelix.main import websocket_manager # Added
+from prompthelix.websocket_manager import ConnectionManager
+
+websocket_manager = ConnectionManager()
 from prompthelix.agents.architect import PromptArchitectAgent
 from prompthelix.agents.results_evaluator import ResultsEvaluatorAgent
 from prompthelix.agents.style_optimizer import StyleOptimizerAgent


### PR DESCRIPTION
## Summary
- add `get_current_user_ui` dependency
- require auth cookie for creating prompts and running experiments
- fix orchestrator websocket import to avoid circular dependency
- clean up message bus register method
- update UI route tests for new auth dependency

## Testing
- `pytest -q` *(fails: OperationalError due to missing tables; multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_b_68508bf2cf208321a083835bbe0fb7fb