### PR TITLE
Require auth for conversation routes

### DIFF
--- a/prompthelix/api/conversation_routes.py
+++ b/prompthelix/api/conversation_routes.py
@@ -2,14 +2,19 @@ from typing import List
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session as DbSession
 from prompthelix.database import get_db
-from prompthelix.schemas import ConversationLogEntry, ConversationSession # Ensure schemas are importable
+from prompthelix.schemas import ConversationLogEntry, ConversationSession
 from prompthelix.services.conversation_service import conversation_service
+from prompthelix.models.user_models import User as UserModel
+from .dependencies import get_current_user
 
 router = APIRouter()
 
 @router.get("/conversations/sessions/", response_model=List[ConversationSession], tags=["Conversations"])
 async def list_conversation_sessions(
-    db: DbSession = Depends(get_db), skip: int = 0, limit: int = 100
+    db: DbSession = Depends(get_db),
+    skip: int = 0,
+    limit: int = 100,
+    current_user: UserModel = Depends(get_current_user),
 ):
     """
     Get a list of all recorded conversation sessions.
@@ -20,7 +25,11 @@ async def list_conversation_sessions(
 
 @router.get("/conversations/sessions/{session_id}/messages/", response_model=List[ConversationLogEntry], tags=["Conversations"])
 async def get_session_messages(
-    session_id: str, db: DbSession = Depends(get_db), skip: int = 0, limit: int = 1000
+    session_id: str,
+    db: DbSession = Depends(get_db),
+    skip: int = 0,
+    limit: int = 1000,
+    current_user: UserModel = Depends(get_current_user),
 ):
     """
     Get all messages for a specific conversation session_id.
@@ -87,7 +96,10 @@ async def get_session_messages(
 
 @router.get("/conversations/all_logs/", response_model=List[ConversationLogEntry], tags=["Conversations"])
 async def get_all_conversation_logs(
-    db: DbSession = Depends(get_db), skip: int = 0, limit: int = 100
+    db: DbSession = Depends(get_db),
+    skip: int = 0,
+    limit: int = 100,
+    current_user: UserModel = Depends(get_current_user),
 ):
     """
     Get all conversation logs across all sessions.

--- a/prompthelix/api/dependencies.py
+++ b/prompthelix/api/dependencies.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy.orm import Session as DbSession
+
+from prompthelix.database import get_db
+from prompthelix.models.user_models import User as UserModel
+from prompthelix.services import user_service
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
+
+async def get_current_user(token: str = Depends(oauth2_scheme), db: DbSession = Depends(get_db)) -> UserModel:
+    db_session = user_service.get_session_by_token(db, session_token=token)
+    if not db_session:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    if db_session.expires_at < datetime.utcnow():
+        user_service.delete_session(db, session_token=token)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session expired",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    user = user_service.get_user(db, user_id=db_session.user_id)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found for session",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return user


### PR DESCRIPTION
## Summary
- add auth dependency helpers
- import auth helpers in API routes
- require auth for conversation routes

## Testing
- `pytest -q` *(fails: SyntaxError in message_bus.py)*

------
https://chatgpt.com/codex/tasks/task_b_68508bf662508321ac7ef64da4980921