### PR TITLE
Add auth tests for conversations and UI

### DIFF
--- a/prompthelix/tests/integration/test_conversation_auth.py
+++ b/prompthelix/tests/integration/test_conversation_auth.py
@@ -1,0 +1,13 @@
+import pytest
+from fastapi.testclient import TestClient
+from prompthelix.tests.utils import get_auth_headers
+
+
+@pytest.mark.parametrize("endpoint", [
+    "/api/v1/conversations/sessions/",
+    "/api/v1/conversations/sessions/s1/messages/",
+    "/api/v1/conversations/all_logs/",
+])
+def test_conversation_endpoints_require_token(client: TestClient, endpoint: str):
+    response = client.get(endpoint)
+    assert response.status_code == 401

--- a/prompthelix/tests/integration/test_ui_login_logout.py
+++ b/prompthelix/tests/integration/test_ui_login_logout.py
@@ -1,0 +1,26 @@
+from fastapi.testclient import TestClient
+from prompthelix.tests.utils import get_auth_headers, DEFAULT_TEST_USERNAME, DEFAULT_TEST_PASSWORD
+
+
+def test_ui_login_sets_cookie_and_logout_clears(client: TestClient, db_session):
+    # ensure user exists and obtain token
+    headers = get_auth_headers(client, db_session)
+    token = headers["Authorization"].split()[1]
+
+    # simulate UI login by setting cookie
+    client.cookies.set("prompthelix_access_token", token)
+    assert client.cookies.get("prompthelix_access_token") == token
+
+    # call protected endpoint using header to verify token valid
+    resp = client.get("/users/me", headers=headers)
+    assert resp.status_code == 200
+
+    # logout via API to invalidate token
+    client.post("/auth/logout", headers=headers)
+    # simulate UI logout clearing cookie
+    client.cookies.set("prompthelix_access_token", "", expires=0)
+    assert client.cookies.get("prompthelix_access_token") == ""
+
+    # request should now fail without auth header
+    resp_after = client.get("/users/me")
+    assert resp_after.status_code == 401


### PR DESCRIPTION
## Summary
- cover conversation endpoints with auth requirement tests
- add UI login/logout flow test ensuring cookies are managed

## Testing
- `pytest -q`
  - fails: `SyntaxError: unterminated triple-quoted string literal (detected at line 333)` in `prompthelix/message_bus.py`

------
https://chatgpt.com/codex/tasks/task_b_68508bf781b883219f4e5c1c1a22cbaf