### PR TITLE
Implement UI login/logout routes

### DIFF
--- a/prompthelix/message_bus.py
+++ b/prompthelix/message_bus.py
@@ -76,31 +76,7 @@ class MessageBus:
             asyncio.create_task(self._broadcast_log_async(log_data))
 
     def register(self, agent_id: str, agent_instance):
-        """
-        Registers an agent instance with the message bus.
-        try:
-            db = self.db_session_factory()
-            log_entry = ConversationLog(
-                session_id=session_id,
-                sender_id=sender_id,
-                recipient_id=recipient_id,
-                message_type=message_type,
-                content=json.dumps(content_payload)
-            )
-            db.add(log_entry)
-            db.commit()
-            logger.debug(f"Message from {sender_id} to {recipient_id} logged to DB. Session: {session_id}, Type: {message_type}")
-        except Exception as e:
-            logger.error(f"Failed to log message to DB: {e}", exc_info=True)
-            if db:
-                db.rollback()
-        finally:
-            if db:
-                db.close()
-
-    def register(self, agent_id: str, agent_instance):
-        """
-        Registers an agent instance with the message bus.
+        """Registers an agent instance with the message bus.
 
         Args:
             agent_id (str): The unique identifier for the agent.

--- a/prompthelix/templates/base.html
+++ b/prompthelix/templates/base.html
@@ -17,18 +17,10 @@
             <li><a href="{{ url_for('ui_dashboard') }}">Dashboard</a></li>
             <li><a href="{{ url_for('view_settings_ui') }}">Settings</a></li>
             <li><a href="{{ url_for('ui_login') }}">Login</a></li>
-            <li><a href="#" onclick="logoutUser()">Logout</a></li>
+            <li><a href="{{ url_for('ui_logout') }}">Logout</a></li>
             <!-- Add other navigation links here -->
         </ul>
     </nav>
-    <script>
-        function logoutUser() {
-            // Clear the access token cookie
-            document.cookie = 'prompthelix_access_token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax';
-            // Redirect to login page
-            window.location.href = "{{ url_for('ui_login') }}";
-        }
-    </script>
     <main>
         {% block content %}{% endblock %}
     </main>

--- a/prompthelix/templates/login.html
+++ b/prompthelix/templates/login.html
@@ -33,17 +33,14 @@
             formData.append('password', password);
 
             try {
-                const response = await fetch('/auth/token', {
+                const response = await fetch('/ui/login', {
                     method: 'POST',
                     body: formData,
                 });
 
-                if (response.ok) {
-                    const data = await response.json();
-                    const token = data.access_token;
-                    // Set cookie
-                    document.cookie = \`prompthelix_access_token=\${token}; Path=/; SameSite=Lax\`;
-                    // Redirect to prompts page
+                if (response.redirected) {
+                    window.location.href = response.url;
+                } else if (response.ok) {
                     window.location.href = '/ui/prompts';
                 } else {
                     const errorData = await response.json();


### PR DESCRIPTION
## Summary
- add POST `/ui/login` and GET `/ui/logout` routes
- set access-token cookie server-side
- update login page JS to call new endpoint
- update base template logout link
- fix syntax issue in `message_bus.py`

## Testing
- `python -m py_compile prompthelix/message_bus.py prompthelix/ui_routes.py`
- `pytest prompthelix/tests/test_ui_routes.py::test_get_login_page_ui -q` *(fails: ImportError: cannot import name 'websocket_manager')*

------
https://chatgpt.com/codex/tasks/task_b_68508bf49e1c83218daa93617afa006d