### PR TITLE
Fix: Correct IndentationError in message_bus.py

### DIFF
--- a/prompthelix/message_bus.py
+++ b/prompthelix/message_bus.py
@@ -76,7 +76,7 @@ class MessageBus:
             asyncio.create_task(self._broadcast_log_async(log_data))
 
     def register(self, agent_id: str, agent_instance):
-      """Registers an agent instance with the message bus.
+        """Registers an agent instance with the message bus.
 
         Args:
             agent_id (str): The unique identifier for the agent.


### PR DESCRIPTION
The original traceback indicated an IndentationError in `prompthelix/message_bus.py`. This change corrects the indentation of the docstring for the `register` method, which was the likely cause of the error.

A lint check was also performed, and no further syntax or indentation errors were found in the file.