### PR TITLE
Refactor: Decouple Orchestrator from GA loop implementation

### DIFF
--- a/prompthelix/experiment_runners/__init__.py
+++ b/prompthelix/experiment_runners/__init__.py
@@ -1,0 +1,5 @@
+# prompthelix/experiment_runners/__init__.py
+from .base_runner import BaseExperimentRunner
+from .ga_runner import GeneticAlgorithmRunner # Add this line
+
+__all__ = ["BaseExperimentRunner", "GeneticAlgorithmRunner"] # Add to __all__

--- a/prompthelix/experiment_runners/base_runner.py
+++ b/prompthelix/experiment_runners/base_runner.py
@@ -1,0 +1,54 @@
+from abc import ABC, abstractmethod
+from typing import Any, Optional, Dict
+
+class BaseExperimentRunner(ABC):
+    """
+    Abstract base class for experiment runners.
+    Defines a common interface for running, controlling, and querying experiments.
+    """
+
+    @abstractmethod
+    def run(self, **kwargs) -> Any:
+        """
+        Execute the experiment.
+
+        Args:
+            **kwargs: Experiment-specific arguments.
+
+        Returns:
+            Any: The result of the experiment (e.g., best chromosome, metrics).
+        """
+        pass
+
+    @abstractmethod
+    def pause(self) -> None:
+        """
+        Pause the currently running experiment, if supported.
+        """
+        pass
+
+    @abstractmethod
+    def resume(self) -> None:
+        """
+        Resume a paused experiment, if supported.
+        """
+        pass
+
+    @abstractmethod
+    def stop(self) -> None:
+        """
+        Stop the currently running experiment.
+        """
+        pass
+
+    @abstractmethod
+    def get_status(self) -> Dict[str, Any]:
+        """
+        Get the current status of the experiment.
+
+        Returns:
+            Dict[str, Any]: A dictionary containing status information.
+                            Common keys might include 'status_message', 'progress',
+                            'details', etc.
+        """
+        pass

--- a/prompthelix/experiment_runners/ga_runner.py
+++ b/prompthelix/experiment_runners/ga_runner.py
@@ -1,0 +1,182 @@
+from typing import Optional, Dict, Any
+import logging
+
+from prompthelix.experiment_runners.base_runner import BaseExperimentRunner
+from prompthelix.genetics.engine import PopulationManager, PromptChromosome
+
+logger = logging.getLogger(__name__)
+
+class GeneticAlgorithmRunner(BaseExperimentRunner):
+    """
+    Runs a genetic algorithm experiment for a specified number of generations.
+    """
+
+    def __init__(self, population_manager: PopulationManager, num_generations: int):
+        """
+        Initializes the GeneticAlgorithmRunner.
+
+        Args:
+            population_manager: A pre-configured PopulationManager instance.
+            num_generations: The total number of generations to run.
+        """
+        if not isinstance(population_manager, PopulationManager):
+            raise TypeError("population_manager must be an instance of PopulationManager.")
+        if not isinstance(num_generations, int) or num_generations <= 0:
+            raise ValueError("num_generations must be a positive integer.")
+
+        self.population_manager = population_manager
+        self.num_generations = num_generations
+        self.current_generation = 0 # Track current generation internally
+        logger.info(
+            f"GeneticAlgorithmRunner initialized for {num_generations} generations "
+            f"with PopulationManager (ID: {id(population_manager)})"
+        )
+
+    def run(self, **kwargs) -> Optional[PromptChromosome]:
+        """
+        Executes the genetic algorithm for the specified number of generations.
+
+        The 'kwargs' are not directly used by this GA runner's core loop but are
+        included for interface compatibility. Specific parameters for GA evolution
+        (like task_description, success_criteria, target_style) should be passed
+        to the PopulationManager's evolve_population method, typically managed
+        by the entity that sets up and calls this runner.
+
+        For this implementation, we'll assume that `task_description`,
+        `success_criteria`, and `target_style` are passed via kwargs to `run`
+        and then forwarded to `evolve_population`. This makes the runner more
+        flexible if these parameters change per run invocation.
+
+        Args:
+            **kwargs: Expected to contain:
+                - task_description (str): Description of the task for evaluation.
+                - success_criteria (Optional[Dict]): Criteria for successful evaluation.
+                - target_style (Optional[str]): Target style for style optimization.
+
+        Returns:
+            Optional[PromptChromosome]: The best chromosome found after all generations
+                                        or if the run was stopped.
+        """
+        logger.info(f"GeneticAlgorithmRunner: Starting run for {self.num_generations} generations.")
+        self.population_manager.status = "RUNNING" # Ensure status is RUNNING at start
+        self.population_manager.broadcast_ga_update(event_type="ga_run_started_runner")
+
+        # Extract GA evolution parameters from kwargs
+        task_description = kwargs.get("task_description")
+        if task_description is None:
+            logger.warning("GeneticAlgorithmRunner.run: 'task_description' not provided in kwargs. Fitness evaluation might be impaired.")
+        success_criteria = kwargs.get("success_criteria")
+        target_style = kwargs.get("target_style")
+
+
+        fittest_individual: Optional[PromptChromosome] = None
+
+        try:
+            for i in range(self.num_generations):
+                self.current_generation = self.population_manager.generation_number + 1 # or i + 1
+                logger.info(f"GeneticAlgorithmRunner: Starting Generation {self.current_generation}/{self.num_generations}")
+
+                if self.population_manager.should_stop:
+                    logger.info(f"GeneticAlgorithmRunner: Stop signal received before Generation {self.current_generation}. Stopping run.")
+                    self.population_manager.status = "STOPPED"
+                    self.population_manager.broadcast_ga_update(event_type="ga_run_stopped_runner_signal")
+                    break
+
+                # evolve_population itself checks for pause/stop and updates status
+                self.population_manager.evolve_population(
+                    task_description=task_description,
+                    success_criteria=success_criteria,
+                    target_style=target_style
+                )
+
+                # If evolve_population itself detected a stop, it would set status to STOPPED
+                if self.population_manager.status == "STOPPED":
+                    logger.info(f"GeneticAlgorithmRunner: PopulationManager entered STOPPED state during Generation {self.current_generation}. Stopping run.")
+                    # population_manager should have broadcasted its stop
+                    break
+
+                fittest_in_gen = self.population_manager.get_fittest_individual()
+                if fittest_in_gen:
+                    logger.info(
+                        f"GeneticAlgorithmRunner: Fittest in Generation {self.population_manager.generation_number}: "
+                        f"Fitness={fittest_in_gen.fitness_score:.4f}, ID={fittest_in_gen.id}"
+                    )
+                    fittest_individual = fittest_in_gen
+                else:
+                    logger.warning(f"GeneticAlgorithmRunner: No fittest individual found in Generation {self.population_manager.generation_number}.")
+
+                # Check for stop signal again after evolution, in case it was set during the generation
+                if self.population_manager.should_stop and self.population_manager.status != "STOPPED":
+                    logger.info(f"GeneticAlgorithmRunner: Stop signal detected after Generation {self.current_generation}. Loop will terminate.")
+                    self.population_manager.status = "STOPPED" # Ensure status is updated if not already
+                    self.population_manager.broadcast_ga_update(event_type="ga_run_stopped_runner_post_gen")
+
+
+            # After the loop
+            if self.population_manager.status not in ["STOPPED", "COMPLETED", "ERROR"]:
+                if self.current_generation >= self.num_generations and not self.population_manager.should_stop:
+                    logger.info(f"GeneticAlgorithmRunner: Completed all {self.num_generations} generations.")
+                    self.population_manager.status = "COMPLETED"
+                    self.population_manager.broadcast_ga_update(event_type="ga_run_completed_runner")
+                elif self.population_manager.should_stop: # Should have been caught by loop breaks
+                    logger.info("GeneticAlgorithmRunner: Run ended due to stop signal (final check).")
+                    if self.population_manager.status != "STOPPED": # Defensive
+                         self.population_manager.status = "STOPPED"
+                         self.population_manager.broadcast_ga_update(event_type="ga_run_stopped_runner_final_check")
+                else:
+                    # Unclear state, perhaps num_generations was 0 or loop exited unexpectedly
+                    logger.warning(f"GeneticAlgorithmRunner: Loop finished, but status is '{self.population_manager.status}'. Generations run: {self.current_generation}/{self.num_generations}.")
+                    # Consider setting to COMPLETED or ERROR based on context
+                    self.population_manager.status = "UNKNOWN_COMPLETION"
+
+
+        except Exception as e:
+            logger.error(f"GeneticAlgorithmRunner: An error occurred during the run: {e}", exc_info=True)
+            self.population_manager.status = "ERROR"
+            self.population_manager.broadcast_ga_update(event_type="ga_run_error_runner", additional_data={"error": str(e)})
+            # Re-raise the exception so the caller (orchestrator) is aware
+            raise
+        finally:
+            final_fittest = self.population_manager.get_fittest_individual()
+            logger.info(
+                f"GeneticAlgorithmRunner: Run finished. Status: {self.population_manager.status}. "
+                f"Final best fitness: {final_fittest.fitness_score if final_fittest else 'N/A'}."
+            )
+            # The orchestrator might want to save the population, or this runner could.
+            # For now, let's assume the orchestrator handles saving if population_path was provided to PopulationManager.
+
+        return self.population_manager.get_fittest_individual() # Return the best one found
+
+    def pause(self) -> None:
+        """Pauses the GA evolution by calling the PopulationManager's method."""
+        logger.info("GeneticAlgorithmRunner: Received pause request.")
+        self.population_manager.pause_evolution()
+
+    def resume(self) -> None:
+        """Resumes the GA evolution by calling the PopulationManager's method."""
+        logger.info("GeneticAlgorithmRunner: Received resume request.")
+        self.population_manager.resume_evolution()
+
+    def stop(self) -> None:
+        """Stops the GA evolution by calling the PopulationManager's method."""
+        logger.info("GeneticAlgorithmRunner: Received stop request.")
+        self.population_manager.stop_evolution()
+
+    def get_status(self) -> Dict[str, Any]:
+        """
+        Gets the current status of the GA from the PopulationManager.
+        Also includes the runner's own current generation and target generations.
+        """
+        pm_status = self.population_manager.get_ga_status()
+        runner_status = {
+            "runner_current_generation": self.current_generation,
+            "runner_target_generations": self.num_generations,
+            "runner_population_manager_id": id(self.population_manager)
+        }
+        # Merge PM status with runner status, giving PM status precedence for shared keys like 'status'
+        # although get_ga_status() returns a dict with keys like 'status', 'generation', etc.
+        # which are distinct from the runner's specific keys here.
+        # A simple update should be fine.
+        status_report = pm_status.copy()
+        status_report.update(runner_status)
+        return status_report

--- a/prompthelix/tests/unit/test_ga_runner.py
+++ b/prompthelix/tests/unit/test_ga_runner.py
@@ -1,0 +1,232 @@
+import unittest
+from unittest.mock import MagicMock, patch, call
+import logging
+
+# Ensure imports for classes being tested or mocked
+from prompthelix.experiment_runners.ga_runner import GeneticAlgorithmRunner
+from prompthelix.genetics.engine import PopulationManager, PromptChromosome
+from prompthelix.message_bus import MessageBus # For mocking if PopulationManager needs it
+
+# Disable most logging for unit tests unless specifically testing log output
+logging.disable(logging.CRITICAL)
+
+class TestGeneticAlgorithmRunner(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_pop_manager = MagicMock(spec=PopulationManager)
+        self.mock_pop_manager.generation_number = 0
+        self.mock_pop_manager.should_stop = False
+        self.mock_pop_manager.status = "IDLE"
+        # Mock the broadcast method that GeneticAlgorithmRunner might call on pop_manager
+        self.mock_pop_manager.broadcast_ga_update = MagicMock()
+        # Mock get_fittest_individual to return a consistent mock chromosome
+        self.mock_fittest_chromosome = MagicMock(spec=PromptChromosome)
+        self.mock_fittest_chromosome.fitness_score = 0.9
+        self.mock_pop_manager.get_fittest_individual.return_value = self.mock_fittest_chromosome
+
+        # Mock evolve_population to simulate generation progression
+        # This will be a shared reference, so tests should be careful if they modify it
+        # or set it directly in the test for specific behaviors.
+        self.shared_evolve_side_effect_details = {'generations_run_in_test': 0}
+
+        # This default side_effect is for simple cases or as a fallback.
+        # Tests with complex run logic will define their own side_effect.
+        def default_evolve_side_effect(*args, **kwargs):
+            # Only increment generation_number if not stopping
+            if not self.mock_pop_manager.should_stop:
+                self.mock_pop_manager.generation_number += 1
+                self.shared_evolve_side_effect_details['generations_run_in_test'] = self.mock_pop_manager.generation_number
+
+            # Use self.num_generations_for_test which should be set by each test method that relies on this default side_effect
+            # This is used to determine when to set status to "COMPLETED" by the mock PM
+            num_generations_target_for_pm_completion = getattr(self, 'num_generations_for_test', 3)
+
+            if self.mock_pop_manager.should_stop:
+                 self.mock_pop_manager.status = "STOPPED"
+            elif self.mock_pop_manager.generation_number >= num_generations_target_for_pm_completion:
+                 self.mock_pop_manager.status = "COMPLETED"
+            else:
+                 self.mock_pop_manager.status = "RUNNING"
+
+        self.mock_pop_manager.evolve_population.side_effect = default_evolve_side_effect
+        self.num_generations_for_test = 3 # Default for setUp, can be overridden by test methods
+
+    def test_init_successful(self):
+        runner = GeneticAlgorithmRunner(self.mock_pop_manager, 5)
+        self.assertIsInstance(runner, GeneticAlgorithmRunner)
+        self.assertEqual(runner.population_manager, self.mock_pop_manager)
+        self.assertEqual(runner.num_generations, 5)
+
+    def test_init_invalid_pop_manager_type(self):
+        with self.assertRaisesRegex(TypeError, "population_manager must be an instance of PopulationManager."):
+            GeneticAlgorithmRunner("not_a_pop_manager", 5)
+
+    def test_init_invalid_num_generations(self):
+        with self.assertRaisesRegex(ValueError, "num_generations must be a positive integer."):
+            GeneticAlgorithmRunner(self.mock_pop_manager, 0)
+        with self.assertRaisesRegex(ValueError, "num_generations must be a positive integer."):
+            GeneticAlgorithmRunner(self.mock_pop_manager, -1)
+
+    def test_run_completes_all_generations(self):
+        self.num_generations_for_test = 3 # Specific to this test, used by the default side_effect
+        # Reset generation_number and other relevant states for this specific test run
+        self.mock_pop_manager.generation_number = 0
+        self.mock_pop_manager.should_stop = False
+        self.mock_pop_manager.status = "IDLE" # Initial status before run
+        self.shared_evolve_side_effect_details['generations_run_in_test'] = 0
+        # Ensure the default side effect is used for this test
+        self.mock_pop_manager.evolve_population.side_effect = self.setUp.__defaults__[0] if hasattr(self.setUp, '__defaults__') and self.setUp.__defaults__ else type(self).setUp.__dict__['evolve_side_effect']
+
+
+        runner = GeneticAlgorithmRunner(self.mock_pop_manager, self.num_generations_for_test)
+
+        run_kwargs = {"task_description": "test task", "success_criteria": {}, "target_style": "formal"}
+        best_chromosome = runner.run(**run_kwargs)
+
+        self.assertEqual(self.mock_pop_manager.evolve_population.call_count, self.num_generations_for_test)
+        # runner.current_generation is updated: self.current_generation = self.population_manager.generation_number + 1
+        # After 3 successful evolutions, pop_manager.generation_number will be 3.
+        # In the loop, runner.current_generation will be 1, then 2, then 3.
+        self.assertEqual(runner.current_generation, self.num_generations_for_test)
+        self.assertEqual(self.mock_pop_manager.status, "COMPLETED") # Set by runner
+        self.mock_pop_manager.broadcast_ga_update.assert_any_call(event_type="ga_run_completed_runner")
+        self.assertEqual(best_chromosome, self.mock_fittest_chromosome)
+
+        expected_call = call(
+            task_description="test task",
+            success_criteria={},
+            target_style="formal"
+        )
+        self.mock_pop_manager.evolve_population.assert_has_calls([expected_call] * self.num_generations_for_test)
+
+
+    def test_run_stops_early_if_should_stop_is_true(self):
+        num_target_generations_for_runner = 5 # Runner aims for 5
+        self.mock_pop_manager.generation_number = 0
+        self.mock_pop_manager.should_stop = False
+        self.mock_pop_manager.status = "IDLE"
+        self.shared_evolve_side_effect_details['generations_run_in_test'] = 0
+
+        runner = GeneticAlgorithmRunner(self.mock_pop_manager, num_target_generations_for_runner)
+
+        generations_evolved_in_test = 0
+        def evolve_side_effect_with_early_stop(*args, **kwargs):
+            nonlocal generations_evolved_in_test
+            # This side effect is specific to this test
+            if self.mock_pop_manager.should_stop:
+                self.mock_pop_manager.status = "STOPPED" # PM might set this if it detects stop early
+                return
+
+            self.mock_pop_manager.generation_number += 1
+            generations_evolved_in_test += 1
+
+            if generations_evolved_in_test == 2: # After 2 successful evolutions
+                self.mock_pop_manager.should_stop = True # Signal stop *before* the next generation check in runner
+                self.mock_pop_manager.status = "RUNNING" # Status after current evolution completes
+            else: # Should not be called if should_stop is true earlier
+                self.mock_pop_manager.status = "RUNNING"
+
+        self.mock_pop_manager.evolve_population.side_effect = evolve_side_effect_with_early_stop
+
+        run_kwargs = {"task_description": "test task"}
+        runner.run(**run_kwargs)
+
+        self.assertEqual(self.mock_pop_manager.evolve_population.call_count, 2) # Evolved twice
+        # current_generation is set at the start of the loop iteration.
+        # Gen 1: current_generation = 1, evolve runs.
+        # Gen 2: current_generation = 2, evolve runs, should_stop becomes true.
+        # Gen 3: current_generation = 3, loop starts, should_stop is true, breaks.
+        # So runner.current_generation will be 3 when it breaks.
+        self.assertEqual(runner.current_generation, 3)
+        self.assertEqual(self.mock_pop_manager.status, "STOPPED") # Runner sets this
+        self.mock_pop_manager.broadcast_ga_update.assert_any_call(event_type="ga_run_stopped_runner_signal")
+
+
+    def test_run_handles_exception_in_evolve_population(self):
+        num_target_generations = 3
+        self.mock_pop_manager.generation_number = 0
+        self.mock_pop_manager.should_stop = False
+        self.mock_pop_manager.status = "IDLE"
+        self.shared_evolve_side_effect_details['generations_run_in_test'] = 0
+
+        runner = GeneticAlgorithmRunner(self.mock_pop_manager, num_target_generations)
+
+        evolve_call_count = 0
+        def evolve_exception_side_effect(*args, **kwargs):
+            nonlocal evolve_call_count
+            evolve_call_count += 1
+            if evolve_call_count == 1: # Raise exception on the first call
+                # PM's generation_number would not have incremented yet by this mock
+                raise Exception("Evolve failed!")
+            # Fallback (should not be reached in this test if exception is handled)
+            self.mock_pop_manager.generation_number +=1
+            self.mock_pop_manager.status="RUNNING"
+
+        self.mock_pop_manager.evolve_population.side_effect = evolve_exception_side_effect
+
+        run_kwargs = {"task_description": "test task"}
+        with self.assertRaisesRegex(Exception, "Evolve failed!"):
+            runner.run(**run_kwargs)
+
+        self.assertEqual(self.mock_pop_manager.status, "ERROR") # Set by runner's except block
+        self.mock_pop_manager.broadcast_ga_update.assert_any_call(
+            event_type="ga_run_error_runner",
+            additional_data={"error": "Evolve failed!"}
+        )
+        self.assertEqual(self.mock_pop_manager.evolve_population.call_count, 1)
+        # runner.current_generation would be 1 when the exception occurred.
+        self.assertEqual(runner.current_generation, 1)
+
+
+    def test_pause_calls_pop_manager_pause(self):
+        runner = GeneticAlgorithmRunner(self.mock_pop_manager, 3)
+        runner.pause()
+        self.mock_pop_manager.pause_evolution.assert_called_once()
+
+    def test_resume_calls_pop_manager_resume(self):
+        runner = GeneticAlgorithmRunner(self.mock_pop_manager, 3)
+        runner.resume()
+        self.mock_pop_manager.resume_evolution.assert_called_once()
+
+    def test_stop_calls_pop_manager_stop(self):
+        runner = GeneticAlgorithmRunner(self.mock_pop_manager, 3)
+        runner.stop()
+        self.mock_pop_manager.stop_evolution.assert_called_once()
+
+    def test_get_status_combines_statuses(self):
+        runner_target_generations = 5
+        runner = GeneticAlgorithmRunner(self.mock_pop_manager, runner_target_generations)
+
+        # Simulate runner being partway through, about to start generation 2
+        runner.current_generation = 2
+
+        # Simulate PopulationManager's actual state: completed 1 generation
+        self.mock_pop_manager.generation_number = 1
+        self.mock_pop_manager.status = "RUNNING" # PM status
+
+        mock_pm_status_payload = {
+            "status": "RUNNING",
+            "generation": self.mock_pop_manager.generation_number,
+            "population_size": 10,
+            "best_fitness": 0.8
+        }
+        self.mock_pop_manager.get_ga_status.return_value = mock_pm_status_payload
+
+        expected_pm_id = id(self.mock_pop_manager)
+
+        status_report = runner.get_status()
+
+        self.mock_pop_manager.get_ga_status.assert_called_once()
+        expected_combined_status = {
+            "status": "RUNNING",
+            "generation": 1,
+            "population_size": 10,
+            "best_fitness": 0.8,
+            "runner_current_generation": 2,
+            "runner_target_generations": runner_target_generations,
+            "runner_population_manager_id": expected_pm_id
+        }
+        self.assertEqual(status_report, expected_combined_status)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I introduced a `BaseExperimentRunner` ABC and a `GeneticAlgorithmRunner` class to encapsulate the genetic algorithm's evolutionary loop.

The `Orchestrator`'s `main_ga_loop` now delegates the execution of generations to the `GeneticAlgorithmRunner`. This change decouples the orchestrator from the specifics of the GA, allowing for easier future extensions with different optimization algorithms and improving testability of the GA loop logic.

Changes include:
- New `BaseExperimentRunner` and `GeneticAlgorithmRunner` classes.
- Refactoring of `prompthelix/orchestrator.py` to use `GeneticAlgorithmRunner`.
- Added unit tests for `PopulationManager` control methods (pause, resume, stop).
- Added new unit tests for `GeneticAlgorithmRunner`.
- Updated integration tests for `test_orchestrator_ga_control.py` to align with the new architecture.