### PR TITLE
feat: Implement real-time debug log streaming to dashboard

### DIFF
--- a/prompthelix/experiment_runners/ga_runner.py
+++ b/prompthelix/experiment_runners/ga_runner.py
@@ -1,10 +1,34 @@
 from typing import Optional, Dict, Any
 import logging
 
+# Add these imports at the top of prompthelix/experiment_runners/ga_runner.py
+from prompthelix.logging_handlers import WebSocketLogHandler
+from prompthelix.globals import websocket_manager # Import the global instance from globals
+
 from prompthelix.experiment_runners.base_runner import BaseExperimentRunner
 from prompthelix.genetics.engine import PopulationManager, PromptChromosome
 
 logger = logging.getLogger(__name__)
+
+# Add the WebSocketLogHandler to the logger instance
+# This setup can be done once when the module is loaded,
+# or specifically when a GeneticAlgorithmRunner is instantiated if preferred.
+# For simplicity, let's add it to the module-level logger.
+# Ensure this part of the code runs when the module is imported.
+
+# Create and configure the WebSocket log handler
+websocket_log_handler = WebSocketLogHandler(connection_manager=websocket_manager)
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(module)s.%(funcName)s:%(lineno)d - %(message)s')
+websocket_log_handler.setFormatter(formatter)
+websocket_log_handler.setLevel(logging.INFO) # Or logging.DEBUG for more verbosity
+
+# Add the handler to the logger
+if not any(isinstance(h, WebSocketLogHandler) for h in logger.handlers):
+    logger.addHandler(websocket_log_handler)
+    logger.info("WebSocketLogHandler added to ga_runner logger.")
+else:
+    logger.info("WebSocketLogHandler already present in ga_runner logger.")
+
 
 class GeneticAlgorithmRunner(BaseExperimentRunner):
     """

--- a/prompthelix/globals.py
+++ b/prompthelix/globals.py
@@ -1,0 +1,19 @@
+# prompthelix/globals.py
+"""
+Global shared instances for the PromptHelix application.
+This module should be kept lightweight and free of complex imports
+to avoid circular dependencies.
+"""
+from prompthelix.websocket_manager import ConnectionManager
+
+# Global WebSocket connection manager instance
+websocket_manager = ConnectionManager()
+
+# You can add other global instances here if needed, e.g., a global MessageBus
+# from prompthelix.database import SessionLocal
+# from prompthelix.message_bus import MessageBus
+# message_bus = MessageBus(db_session_factory=SessionLocal, connection_manager=websocket_manager)
+# Note: If adding MessageBus here, ensure SessionLocal import doesn't create cycles.
+# For now, only websocket_manager is strictly needed to break the current cycle.
+
+print("PromptHelix Config: GLOBALS - websocket_manager initialized.")

--- a/prompthelix/logging_handlers.py
+++ b/prompthelix/logging_handlers.py
@@ -1,0 +1,31 @@
+import logging
+import html # Import the html module
+import asyncio # Moved import to module level
+from prompthelix.websocket_manager import ConnectionManager
+
+class WebSocketLogHandler(logging.Handler):
+    def __init__(self, connection_manager: ConnectionManager):
+        super().__init__()
+        self.connection_manager = connection_manager
+
+    def emit(self, record: logging.LogRecord):
+        try:
+            log_entry = self.format(record)
+            # Escape HTML characters in the log message
+            escaped_log_entry = html.escape(log_entry)
+            log_data = {
+                "type": "debug_log",
+                "data": {
+                    "timestamp": record.created,
+                    "level": record.levelname,
+                    "message": escaped_log_entry, # Use the escaped message
+                    "module": record.module,
+                    "funcName": record.funcName,
+                    "lineno": record.lineno,
+                }
+            }
+            # Use asyncio.create_task to run the async broadcast_json method
+            # import asyncio # No longer imported locally
+            asyncio.create_task(self.connection_manager.broadcast_json(log_data))
+        except Exception:
+            self.handleError(record)

--- a/prompthelix/main.py
+++ b/prompthelix/main.py
@@ -11,7 +11,8 @@ from fastapi.staticfiles import StaticFiles
 from prompthelix.templating import templates # Import templates object
 from prompthelix.api import routes as api_routes
 from prompthelix.ui_routes import router as ui_router # Import the UI router
-from prompthelix.websocket_manager import ConnectionManager
+# from prompthelix.websocket_manager import ConnectionManager # No longer imported directly for instantiation
+from prompthelix.globals import websocket_manager # Import the global instance
 from prompthelix.database import init_db
 
 # Call init_db to create database tables on startup
@@ -20,7 +21,7 @@ init_db()
 
 # Initialize FastAPI application
 app = FastAPI()
-websocket_manager = ConnectionManager() # Renamed and confirmed module level
+# websocket_manager = ConnectionManager() # websocket_manager is now imported from globals
 
 # Mount static files
 # templates object is now imported, no need to initialize here

--- a/prompthelix/orchestrator.py
+++ b/prompthelix/orchestrator.py
@@ -13,7 +13,7 @@ from prompthelix.agents.domain_expert import DomainExpertAgent # Added for demo
 from prompthelix.agents.critic import PromptCriticAgent # Added for demo
 # Import BaseAgent if we need to use it for the example, or a mock agent
 from prompthelix.agents.base import BaseAgent
-from prompthelix.experiment_runners import GeneticAlgorithmRunner # Added import
+from prompthelix.experiment_runners.ga_runner import GeneticAlgorithmRunner # Changed import
 from prompthelix.genetics.engine import (
     GeneticOperators,
     FitnessEvaluator,

--- a/prompthelix/templates/dashboard.html
+++ b/prompthelix/templates/dashboard.html
@@ -29,6 +29,21 @@
             <!-- Logs will be appended here by JavaScript -->
             <div class="log-entry text-gray-500">Waiting for logs...</div>
         </div>
+    </section> <!-- Conversation Logs Section -->
+
+    <!-- Debug Logs Section -->
+    <section id="debug-logs" class="mb-6 p-4 bg-white rounded shadow">
+        <div class="flex justify-between items-center mb-3">
+            <h2 class="text-xl font-semibold">Real-Time Debug Logs</h2>
+            <div class="flex items-center">
+                <input type="checkbox" id="toggle-debug-logs" class="form-checkbox h-5 w-5 text-blue-600 rounded focus:ring-blue-500" checked>
+                <label for="toggle-debug-logs" class="ml-2 text-sm text-gray-700">Show Debug Logs</label>
+            </div>
+        </div>
+        <div id="debug-logs-container" class="max-h-96 overflow-y-auto space-y-2 pr-2 border rounded p-2 bg-gray-50">
+            <!-- Debug logs will be appended here by JavaScript -->
+            <div class="log-entry text-gray-500">Waiting for debug logs...</div>
+        </div>
     </section>
 
     <!-- Agent Metrics Section -->
@@ -51,6 +66,9 @@
         const gaFittestChromosome = document.getElementById('ga-fittest-chromosome'); // Added
         const logsContainer = document.getElementById('logs-container');
         const agentMetricsData = document.getElementById('agent-metrics-data');
+        const debugLogsContainer = document.getElementById('debug-logs-container'); // Add this
+        const toggleDebugLogs = document.getElementById('toggle-debug-logs'); // Add this
+
 
         // Determine WebSocket protocol
         const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -109,6 +127,47 @@
 
                 logsContainer.appendChild(logEntry);
                 logsContainer.scrollTop = logsContainer.scrollHeight; // Auto-scroll
+            } else if (message.type === 'debug_log' && message.data) {
+                const debugLogsContainer = document.getElementById('debug-logs-container'); // Re-fetch or ensure it's in scope
+                const toggleDebugLogs = document.getElementById('toggle-debug-logs'); // Re-fetch or ensure it's in scope
+
+                if (toggleDebugLogs && toggleDebugLogs.checked) {
+                    const logEntry = document.createElement('div');
+                    logEntry.classList.add('log-entry', 'p-1', 'rounded', 'text-xs', 'mb-1', 'font-mono'); // Added font-mono
+
+                    const level = message.data.level ? message.data.level.toLowerCase() : 'info';
+                    if (level === 'error') {
+                        logEntry.classList.add('bg-red-50', 'text-red-700');
+                    } else if (level === 'warning') {
+                        logEntry.classList.add('bg-yellow-50', 'text-yellow-700');
+                    } else if (level === 'debug') {
+                        logEntry.classList.add('bg-blue-50', 'text-blue-700');
+                    } else {
+                        logEntry.classList.add('bg-gray-100');
+                    }
+
+                    const timestamp = new Date(message.data.timestamp * 1000).toLocaleTimeString();
+                    const logMessage = message.data.message || '';
+                    const module = message.data.module || 'unknown_module';
+                    const funcName = message.data.funcName || 'unknown_function';
+                    const lineno = message.data.lineno || '?';
+
+                    logEntry.innerHTML = `
+                        <div class="grid grid-cols-12 gap-x-1">
+                            <span class="col-span-2 text-gray-600">${timestamp}</span>
+                            <span class="col-span-1 font-semibold ${level === 'error' || level === 'warning' ? '' : 'text-gray-700'}">${message.data.level}</span>
+                            <span class="col-span-3 text-purple-600">${module}.${funcName}:${lineno}</span>
+                            <span class="col-span-6">${logMessage}</span>
+                        </div>
+                    `;
+
+                    const waitingMsg = debugLogsContainer.querySelector('.text-gray-500');
+                    if (waitingMsg && waitingMsg.textContent === 'Waiting for debug logs...') {
+                        debugLogsContainer.innerHTML = '';
+                    }
+                    debugLogsContainer.appendChild(logEntry);
+                    debugLogsContainer.scrollTop = debugLogsContainer.scrollHeight; // Auto-scroll
+                }
             } else if (message.type === 'ga_update' && message.data) {
                 // Placeholder for GA updates
                 gaStatus.textContent = message.data.status || 'N/A';

--- a/prompthelix/tests/unit/test_ga_runner.py
+++ b/prompthelix/tests/unit/test_ga_runner.py
@@ -1,18 +1,21 @@
 import unittest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch, call, AsyncMock
 import logging
+import asyncio # For asyncio.create_task patching
 
 # Ensure imports for classes being tested or mocked
 from prompthelix.experiment_runners.ga_runner import GeneticAlgorithmRunner
 from prompthelix.genetics.engine import PopulationManager, PromptChromosome
 from prompthelix.message_bus import MessageBus # For mocking if PopulationManager needs it
+from prompthelix.websocket_manager import ConnectionManager # Added import
 
 # Disable most logging for unit tests unless specifically testing log output
-logging.disable(logging.CRITICAL)
+logging.disable(logging.CRITICAL) # Global disable
 
 class TestGeneticAlgorithmRunner(unittest.TestCase):
 
     def setUp(self):
+        # ... (existing setUp code) ...
         self.mock_pop_manager = MagicMock(spec=PopulationManager)
         self.mock_pop_manager.generation_number = 0
         self.mock_pop_manager.should_stop = False
@@ -22,34 +25,40 @@ class TestGeneticAlgorithmRunner(unittest.TestCase):
         # Mock get_fittest_individual to return a consistent mock chromosome
         self.mock_fittest_chromosome = MagicMock(spec=PromptChromosome)
         self.mock_fittest_chromosome.fitness_score = 0.9
+        self.mock_fittest_chromosome.id = "mock_chromosome_id_123" # Add id attribute
         self.mock_pop_manager.get_fittest_individual.return_value = self.mock_fittest_chromosome
 
         # Mock evolve_population to simulate generation progression
-        # This will be a shared reference, so tests should be careful if they modify it
-        # or set it directly in the test for specific behaviors.
         self.shared_evolve_side_effect_details = {'generations_run_in_test': 0}
 
-        # This default side_effect is for simple cases or as a fallback.
-        # Tests with complex run logic will define their own side_effect.
         def default_evolve_side_effect(*args, **kwargs):
-            # Only increment generation_number if not stopping
             if not self.mock_pop_manager.should_stop:
                 self.mock_pop_manager.generation_number += 1
                 self.shared_evolve_side_effect_details['generations_run_in_test'] = self.mock_pop_manager.generation_number
-
-            # Use self.num_generations_for_test which should be set by each test method that relies on this default side_effect
-            # This is used to determine when to set status to "COMPLETED" by the mock PM
-            num_generations_target_for_pm_completion = getattr(self, 'num_generations_for_test', 3)
-
-            if self.mock_pop_manager.should_stop:
-                 self.mock_pop_manager.status = "STOPPED"
-            elif self.mock_pop_manager.generation_number >= num_generations_target_for_pm_completion:
-                 self.mock_pop_manager.status = "COMPLETED"
+                self.mock_pop_manager.status = "RUNNING" # Runner should determine COMPLETED
             else:
-                 self.mock_pop_manager.status = "RUNNING"
+                self.mock_pop_manager.status = "STOPPED"
 
-        self.mock_pop_manager.evolve_population.side_effect = default_evolve_side_effect
-        self.num_generations_for_test = 3 # Default for setUp, can be overridden by test methods
+        self.default_evolve_side_effect = default_evolve_side_effect
+        self.mock_pop_manager.evolve_population.side_effect = self.default_evolve_side_effect
+        self.num_generations_for_test = 3
+
+        self.ga_runner_logger = logging.getLogger('prompthelix.experiment_runners.ga_runner')
+        self.original_ga_runner_logger_handlers = list(self.ga_runner_logger.handlers)
+        self.original_ga_runner_logger_level = self.ga_runner_logger.level
+        self.original_ga_runner_logger_disabled_status = self.ga_runner_logger.disabled
+
+        self.ga_runner_logger.setLevel(logging.INFO)
+        self.ga_runner_logger.disabled = False
+
+        # This test class might add its own handler for specific tests,
+        # so original handlers are stored to be restored.
+
+    def tearDown(self):
+        self.ga_runner_logger.setLevel(self.original_ga_runner_logger_level)
+        self.ga_runner_logger.disabled = self.original_ga_runner_logger_disabled_status
+        # Restore original handlers, removing any added during tests
+        self.ga_runner_logger.handlers = self.original_ga_runner_logger_handlers
 
     def test_init_successful(self):
         runner = GeneticAlgorithmRunner(self.mock_pop_manager, 5)
@@ -75,7 +84,7 @@ class TestGeneticAlgorithmRunner(unittest.TestCase):
         self.mock_pop_manager.status = "IDLE" # Initial status before run
         self.shared_evolve_side_effect_details['generations_run_in_test'] = 0
         # Ensure the default side effect is used for this test
-        self.mock_pop_manager.evolve_population.side_effect = self.setUp.__defaults__[0] if hasattr(self.setUp, '__defaults__') and self.setUp.__defaults__ else type(self).setUp.__dict__['evolve_side_effect']
+        self.mock_pop_manager.evolve_population.side_effect = self.default_evolve_side_effect
 
 
         runner = GeneticAlgorithmRunner(self.mock_pop_manager, self.num_generations_for_test)
@@ -227,6 +236,107 @@ class TestGeneticAlgorithmRunner(unittest.TestCase):
             "runner_population_manager_id": expected_pm_id
         }
         self.assertEqual(status_report, expected_combined_status)
+
+    @patch('prompthelix.globals.websocket_manager.broadcast_json', new_callable=AsyncMock) # Reverted to AsyncMock
+    @patch('prompthelix.logging_handlers.asyncio.create_task') # Corrected patch target for create_task
+    def test_ga_runner_init_logs_are_sent_via_websocket_handler(self, mock_create_task, mock_broadcast_json_patched_on_globals): # Name back to original
+        # This test verifies the integration of ga_runner's logging with WebSocketLogHandler.
+
+        # The WebSocketLogHandler in ga_runner.py is added at module import time and
+        # captures the original websocket_manager.broadcast_json.
+        # Patching prompthelix.globals.websocket_manager.broadcast_json directly in the test
+        # won't affect the already configured handler instance.
+        # Instead, we need to replace the handler or its connection_manager's broadcast_json.
+
+        ga_logger = logging.getLogger('prompthelix.experiment_runners.ga_runner')
+        original_handlers = list(ga_logger.handlers) # Store original handlers
+
+        # Find the existing WebSocketLogHandler and temporarily replace its connection_manager's method
+        # OR, more robustly, remove it and add a new one with a mock connection manager.
+
+        # Create a new mock connection manager for this test
+        test_mock_connection_manager = MagicMock(spec=ConnectionManager)
+        test_mock_connection_manager.broadcast_json = mock_broadcast_json_patched_on_globals # Use original name
+
+        # Import WebSocketLogHandler here to avoid issues if it's not yet fully imported elsewhere
+        from prompthelix.logging_handlers import WebSocketLogHandler
+        test_ws_log_handler = WebSocketLogHandler(connection_manager=test_mock_connection_manager)
+        test_ws_log_handler.setLevel(logging.INFO) # Ensure it processes INFO logs
+        formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(module)s.%(funcName)s:%(lineno)d - %(message)s')
+        test_ws_log_handler.setFormatter(formatter)
+
+        # Remove existing WebSocketLogHandlers and add our test-specific one
+        ga_logger.handlers = [h for h in original_handlers if not isinstance(h, WebSocketLogHandler)]
+        ga_logger.addHandler(test_ws_log_handler)
+
+        # Ensure logger is enabled (it's handled in setUp/tearDown generally, but double check for this specific logger)
+        ga_logger.disabled = False
+        ga_logger.setLevel(logging.INFO)
+
+        # Temporarily change global logging disable level for this test
+        original_global_disable_level = logging.root.manager.disable
+        logging.disable(logging.NOTSET) # Allow INFO logs globally
+
+
+        def side_effect_for_create_task(coro):
+            try:
+                coro.send(None)
+            except StopIteration:
+                pass
+            except Exception:
+                coro.close()
+            return MagicMock()
+
+        mock_create_task.side_effect = side_effect_for_create_task
+
+        # Wrap the test handler's emit method to check if it's called
+        original_emit = test_ws_log_handler.emit
+        test_ws_log_handler.emit = MagicMock(wraps=original_emit)
+
+        num_generations = 5
+        # Instantiating GeneticAlgorithmRunner should trigger its __init__ log
+        runner = GeneticAlgorithmRunner(self.mock_pop_manager, num_generations)
+
+        # Debug: Check if the test handler's emit was called
+        self.assertTrue(test_ws_log_handler.emit.called, "Test WebSocketLogHandler's emit method was not called.")
+
+        # Assert that our mock (indirectly via test_mock_connection_manager) was called
+        self.assertTrue(mock_broadcast_json_patched_on_globals.called, # Use original name
+                        "Patched broadcast_json (via test_mock_connection_manager) was not called.")
+
+        found_init_log = False
+        # The WebSocketLogHandler in ga_runner.py is configured with a specific formatter:
+        # '%(asctime)s - %(name)s - %(levelname)s - %(module)s.%(funcName)s:%(lineno)d - %(message)s'
+        # The 'message' part of the log_payload['message'] will be the raw message given to logger.info()
+        # The other fields like module, funcName, etc., are separate in log_payload.
+
+        for call_args in mock_broadcast_json_patched_on_globals.call_args_list: # Corrected variable name
+            log_data_sent = call_args[0][0]
+            if log_data_sent.get('type') == 'debug_log':
+                log_payload = log_data_sent.get('data', {})
+
+                # Check for the specific message from GeneticAlgorithmRunner.__init__
+                # The logged message is:
+                # f"GeneticAlgorithmRunner initialized for {num_generations} generations "
+                # f"with PopulationManager (ID: {id(population_manager)})"
+                # We check for a substring.
+                if ("GeneticAlgorithmRunner initialized" in log_payload.get('message', "") and
+                    log_payload.get('module') == 'ga_runner' and
+                    log_payload.get('funcName') == '__init__'):
+                    found_init_log = True
+                    self.assertEqual(log_payload.get('level'), 'INFO')
+                    self.assertIn(f"for {num_generations} generations", log_payload.get('message', ""))
+                    self.assertIn(f"with PopulationManager (ID: {id(self.mock_pop_manager)})", log_payload.get('message', ""))
+                    break
+
+        self.assertTrue(found_init_log,
+                        f"The specific GA Runner __init__ log message was not found. Calls: {mock_broadcast_json_patched_on_globals.call_args_list}") # Use original name
+
+        # Restore original handlers after the test
+        ga_logger.handlers = original_handlers
+        # Restore global logging disable level
+        logging.disable(original_global_disable_level)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/prompthelix/tests/unit/test_logging_handlers.py
+++ b/prompthelix/tests/unit/test_logging_handlers.py
@@ -1,0 +1,222 @@
+# prompthelix/tests/unit/test_logging_handlers.py
+import unittest
+import logging
+import asyncio
+from unittest.mock import MagicMock, patch, AsyncMock
+
+# Adjust the import path based on your project structure
+from prompthelix.logging_handlers import WebSocketLogHandler
+from prompthelix.websocket_manager import ConnectionManager # Assuming this is the correct path
+
+class TestWebSocketLogHandler(unittest.TestCase):
+
+    def setUp(self):
+        # Create a mock ConnectionManager
+        self.mock_connection_manager = MagicMock(spec=ConnectionManager)
+        # Mock the broadcast_json method to be an AsyncMock
+        self.mock_connection_manager.broadcast_json = AsyncMock()
+
+        # Create an instance of the handler
+        self.handler = WebSocketLogHandler(connection_manager=self.mock_connection_manager)
+
+        # Create a logger and add the handler to it
+        self.logger = logging.getLogger('test_websocket_logger')
+        self.logger.setLevel(logging.DEBUG) # Process all levels for testing
+
+        # Clear existing handlers and add our test handler
+        if self.logger.hasHandlers():
+            self.logger.handlers.clear()
+        self.logger.addHandler(self.handler)
+
+        # Set a simple formatter for consistent output testing if needed
+        formatter = logging.Formatter('%(message)s') # Basic formatter for this test
+        self.handler.setFormatter(formatter)
+
+
+    @patch('asyncio.create_task')
+    def test_emit_sends_correct_log_data_structure(self, mock_create_task):
+        # Arrange
+        log_message = "Test log message with <html> characters."
+        expected_escaped_message = "Test log message with &lt;html&gt; characters."
+
+        # Act
+        # self.logger.info(log_message) # Original call, will be called again after side_effect modification
+
+        # Assert
+        # Check if asyncio.create_task was called
+        # mock_create_task.assert_called_once() # This will be checked after the second log call
+
+        # Get the coroutine passed to create_task (it's the first argument of the first call)
+        # coro_call = mock_create_task.call_args[0][0]
+
+        # To check what broadcast_json would have been called with, we need to simulate
+        # the execution of the coroutine. Since broadcast_json is an AsyncMock,
+        # we can check its call arguments directly after it's "awaited" by create_task.
+        # However, create_task itself doesn't await here, it schedules.
+        # For simplicity in a unit test, we can check the arguments passed to broadcast_json
+        # by assuming create_task would eventually run it.
+
+        # To properly test the call to an async method wrapped by create_task,
+        # we can make the mock_connection_manager.broadcast_json a MagicMock (non-async)
+        # if we don't want to involve asyncio loop in the test.
+        # Or, if we keep it AsyncMock, we need to ensure the event loop runs.
+        # Let's re-evaluate. The handler calls asyncio.create_task(self.connection_manager.broadcast_json(log_data))
+        # So, mock_create_task will be called with broadcast_json(log_data).
+        # The argument to mock_create_task is the coroutine object.
+
+        # We need to check the arguments of the `broadcast_json` call.
+        # The `broadcast_json` itself is an AsyncMock. When `create_task` is called
+        # with `self.connection_manager.broadcast_json(log_data)`, the `log_data` is
+        # evaluated at that point.
+        # The call to create_task is `create_task(coroutine)`.
+        # The coroutine is `self.mock_connection_manager.broadcast_json.func(log_data_arg)`.
+        # This is a bit tricky to get the `log_data_arg` directly from `mock_create_task`.
+
+        # Alternative: Check call_args on the mock_connection_manager.broadcast_json directly
+        # This requires the task to have been run.
+        # For unit testing, let's assume create_task will execute the passed coroutine.
+        # The simplest way is to check the arguments of broadcast_json directly if create_task
+        # is patched to call its argument.
+
+        # Let's redefine mock_create_task to execute the coroutine immediately for testing
+        def side_effect_for_create_task(coro):
+            # This is a simplified way to run the coro for testing.
+            # In a real scenario, an event loop would manage this.
+            try:
+                coro.send(None) # Start the coroutine
+            except StopIteration:
+                pass # Coroutine completed
+            except Exception as e:
+                print(f"Coroutine execution failed in test: {e}")
+            return MagicMock() # Return a mock task object
+
+        mock_create_task.side_effect = side_effect_for_create_task
+
+        self.logger.info(log_message) # Log again with the new side_effect
+
+        mock_create_task.assert_called_once() # ensure create_task was called
+        self.mock_connection_manager.broadcast_json.assert_called_once()
+        called_with_log_data = self.mock_connection_manager.broadcast_json.call_args[0][0]
+
+        self.assertEqual(called_with_log_data['type'], 'debug_log')
+        self.assertIn('data', called_with_log_data)
+        log_payload = called_with_log_data['data']
+
+        self.assertEqual(log_payload['level'], 'INFO')
+        self.assertEqual(log_payload['message'], expected_escaped_message)
+        self.assertEqual(log_payload['module'], 'test_logging_handlers') # This file
+        self.assertIn('timestamp', log_payload)
+        self.assertEqual(log_payload['funcName'], 'test_emit_sends_correct_log_data_structure')
+        self.assertIn('lineno', log_payload)
+
+
+    @patch('asyncio.create_task')
+    def test_emit_html_escaping(self, mock_create_task):
+        original_broadcast_json = self.mock_connection_manager.broadcast_json
+        sync_broadcast_mock = MagicMock(name="sync_broadcast_mock_for_html_escaping")
+
+        # Define a side effect for create_task that simply executes the coroutine.
+        # The key is that self.mock_connection_manager.broadcast_json will be
+        # the sync_broadcast_mock when the logger.info call happens.
+        def run_coro_immediately_side_effect(coro):
+            try:
+                coro.send(None)  # Start/run the coroutine
+            except StopIteration:
+                pass  # Coroutine completed
+            except Exception as e:
+                print(f"Coroutine execution failed in test_emit_html_escaping: {e}")
+            return MagicMock(name="mock_task_object")
+
+        mock_create_task.side_effect = run_coro_immediately_side_effect
+
+        test_cases = [
+            ("simple", "simple"),
+            ("<a>link</a>", "&lt;a&gt;link&lt;/a&gt;"),
+            ("text with 'quotes' and \"double quotes\"", "text with &#x27;quotes&#x27; and &quot;double quotes&quot;"),
+            ("<script>alert('xss')</script>", "&lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt;")
+        ]
+
+        try:
+            # Replace the ConnectionManager's broadcast_json with our sync mock BEFORE logging
+            self.mock_connection_manager.broadcast_json = sync_broadcast_mock
+
+            for raw_message, expected_escaped_message in test_cases:
+                with self.subTest(raw_message=raw_message):
+                    sync_broadcast_mock.reset_mock() # Reset for each sub-test
+                    mock_create_task.reset_mock() # Reset create_task mock as well
+
+                    self.logger.info(raw_message)
+
+                    mock_create_task.assert_called_once() # Ensure create_task was involved
+                    sync_broadcast_mock.assert_called_once() # Crucial: check the sync mock
+
+                    called_with_log_data = sync_broadcast_mock.call_args[0][0]
+                    self.assertEqual(called_with_log_data['data']['message'], expected_escaped_message)
+        finally:
+            # Restore the original broadcast_json mock AFTER all tests are done
+            self.mock_connection_manager.broadcast_json = original_broadcast_json
+
+
+    def test_handler_level_respects_logger_level(self):
+        # This test is more about logging configuration than the handler itself.
+        # The handler itself doesn't filter by level initially if its own level is NOTSET;
+        # that's the logger's job. If the handler has a specific level set, it filters further.
+
+        # Set handler level to a low level (DEBUG) so it doesn't filter out messages passed by logger
+        self.handler.setLevel(logging.DEBUG)
+        # Ensure logger is also at DEBUG to pass messages through
+        self.logger.setLevel(logging.DEBUG)
+
+        # Temporarily remove and re-add handler to make sure level settings are applied if there's caching
+        self.logger.removeHandler(self.handler)
+        self.logger.addHandler(self.handler)
+
+        def simple_coro_runner(coro):
+            try:
+                coro.send(None)
+            except StopIteration:
+                pass
+            return MagicMock()
+
+        with patch('asyncio.create_task', MagicMock(side_effect=simple_coro_runner)) as mock_task:
+            self.mock_connection_manager.broadcast_json.reset_mock()
+            self.logger.debug("A debug message.")
+            self.mock_connection_manager.broadcast_json.assert_called_once()
+
+            self.mock_connection_manager.broadcast_json.reset_mock()
+            self.logger.info("An info message.")
+            self.mock_connection_manager.broadcast_json.assert_called_once()
+
+    def test_handler_filters_by_its_own_level(self):
+        self.handler.setLevel(logging.WARNING) # Handler will only process WARNING and above
+        self.logger.setLevel(logging.DEBUG) # Logger allows DEBUG and above (passes more to handler)
+
+        # Ensure handler is fresh with this level
+        self.logger.removeHandler(self.handler)
+        self.logger.addHandler(self.handler)
+
+        def simple_coro_runner(coro):
+            try:
+                coro.send(None)
+            except StopIteration:
+                pass
+            return MagicMock()
+
+        with patch('asyncio.create_task', MagicMock(side_effect=simple_coro_runner)) as mock_task:
+            self.mock_connection_manager.broadcast_json.reset_mock()
+
+            self.logger.debug("This should be filtered by handler.")
+            self.mock_connection_manager.broadcast_json.assert_not_called()
+
+            self.logger.info("This should also be filtered by handler.")
+            self.mock_connection_manager.broadcast_json.assert_not_called()
+
+            self.logger.warning("This should be processed.")
+            self.mock_connection_manager.broadcast_json.assert_called_once()
+
+            self.mock_connection_manager.broadcast_json.reset_mock()
+            self.logger.error("This should also be processed.")
+            self.mock_connection_manager.broadcast_json.assert_called_once()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This feature enables the streaming of debug logs from the Genetic Algorithm runner to your UI dashboard in real-time.

Key changes include:

1.  **WebSocketLogHandler**: A new logging handler (`prompthelix.logging_handlers.WebSocketLogHandler`) was created. This handler formats log records and uses the global `websocket_manager` to broadcast them as JSON messages with `type: "debug_log"`. Messages are HTML-escaped.

2.  **GA Runner Integration**: The `WebSocketLogHandler` is added to the logger in `prompthelix.experiment_runners.ga_runner`, allowing logs from the GA execution to be captured.

3.  **Global WebSocket Manager**: Introduced `prompthelix.globals.py` to host the `websocket_manager` instance. This resolves a circular dependency issue and provides a central point for accessing the manager. `main.py` and `ga_runner.py` now import `websocket_manager` from here.

4.  **Dashboard UI Update**:
    *   Added a new "Real-Time Debug Logs" section to `prompthelix/templates/dashboard.html`.
    *   Included a toggle switch to allow you to show/hide these logs.
    *   Updated the dashboard's JavaScript to connect to the WebSocket, listen for `debug_log` messages, and display them in the new section, respecting the toggle's state. Log messages are styled based on their level.

5.  **Testing**:
    *   Added unit tests for `WebSocketLogHandler` (`prompthelix/tests/unit/test_logging_handlers.py`) to verify its formatting, HTML escaping, and interaction with the connection manager.
    *   Added an integration test to `prompthelix/tests/unit/test_ga_runner.py` (`test_ga_runner_init_logs_are_sent_via_websocket_handler`) to ensure that logs generated by the `GeneticAlgorithmRunner` are correctly processed by the `WebSocketLogHandler` and prepared for broadcasting. This involved careful mocking and patching to test the logging pipeline.

This provides valuable real-time insight into the experiment execution process for debugging and monitoring purposes.