### PR TITLE
feat: Implement GA experiment controls and dashboard UI

### DIFF
--- a/prompthelix/experiment_runners/ga_runner.py
+++ b/prompthelix/experiment_runners/ga_runner.py
@@ -4,6 +4,7 @@ import logging
 # Add these imports at the top of prompthelix/experiment_runners/ga_runner.py
 from prompthelix.logging_handlers import WebSocketLogHandler
 from prompthelix.globals import websocket_manager # Import the global instance from globals
+from prompthelix import globals as ph_globals
 
 from prompthelix.experiment_runners.base_runner import BaseExperimentRunner
 from prompthelix.genetics.engine import PopulationManager, PromptChromosome
@@ -76,6 +77,8 @@ class GeneticAlgorithmRunner(BaseExperimentRunner):
             f"GeneticAlgorithmRunner initialized for {num_generations} generations "
             f"with PopulationManager (ID: {id(population_manager)})"
         )
+        ph_globals.active_ga_runner = self
+        logger.info(f"GeneticAlgorithmRunner instance {id(self)} registered as active_ga_runner.")
 
     def run(self, **kwargs) -> Optional[PromptChromosome]:
         """
@@ -182,6 +185,9 @@ class GeneticAlgorithmRunner(BaseExperimentRunner):
             # Re-raise the exception so the caller (orchestrator) is aware
             raise
         finally:
+            if ph_globals.active_ga_runner is self:
+                ph_globals.active_ga_runner = None
+                logger.info(f"GeneticAlgorithmRunner instance {id(self)} unregistered as active_ga_runner.")
             final_fittest = self.population_manager.get_fittest_individual()
             logger.info(
                 f"GeneticAlgorithmRunner: Run finished. Status: {self.population_manager.status}. "

--- a/prompthelix/globals.py
+++ b/prompthelix/globals.py
@@ -4,10 +4,19 @@ Global shared instances for the PromptHelix application.
 This module should be kept lightweight and free of complex imports
 to avoid circular dependencies.
 """
+from typing import Optional
+# Forward reference for GeneticAlgorithmRunner to avoid circular import issues
+# as experiment_runners.ga_runner will import this file.
+if False: # TYPE_CHECKING can also be used here if preferred
+    from prompthelix.experiment_runners.ga_runner import GeneticAlgorithmRunner
+
 from prompthelix.websocket_manager import ConnectionManager
 
 # Global WebSocket connection manager instance
 websocket_manager = ConnectionManager()
+
+# Definition for the active Genetic Algorithm runner
+active_ga_runner: Optional["GeneticAlgorithmRunner"] = None
 
 # You can add other global instances here if needed, e.g., a global MessageBus
 # from prompthelix.database import SessionLocal

--- a/prompthelix/schemas.py
+++ b/prompthelix/schemas.py
@@ -197,3 +197,20 @@ class ConversationSession(BaseModel):
     message_count: int
     first_message_at: datetime
     last_message_at: datetime
+
+# --- GA Status Schema ---
+class GAStatusResponse(BaseModel):
+    status: str
+    generation: int
+    population_size: int
+    best_fitness: Optional[float] = None
+    fittest_individual_id: Optional[str] = None # Using str for UUID representation
+    fittest_chromosome_string: Optional[str] = None
+    agents_used: Optional[List[str]] = []
+    # Fields from GeneticAlgorithmRunner.get_status()
+    runner_current_generation: Optional[int] = None
+    runner_target_generations: Optional[int] = None
+    runner_population_manager_id: Optional[int] = None
+    # Fields from PopulationManager often included in status broadcasts
+    is_paused: Optional[bool] = None
+    should_stop: Optional[bool] = None

--- a/prompthelix/templates/dashboard.html
+++ b/prompthelix/templates/dashboard.html
@@ -15,6 +15,11 @@
             <p>Best Fitness: <span id="ga-best-fitness">-</span></p>
             <p>Agents Used: <span id="ga-agents-used">-</span></p>
             <p>Fittest Chromosome: <pre id="ga-fittest-chromosome">-</pre></p>
+            <div class="mt-4 flex space-x-2">
+                <button id="ga-pause-btn" class="bg-yellow-500 hover:bg-yellow-700 text-white font-bold py-2 px-4 rounded disabled:opacity-50">Pause</button>
+                <button id="ga-resume-btn" class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded disabled:opacity-50">Resume</button>
+                <button id="ga-cancel-btn" class="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded disabled:opacity-50">Cancel</button>
+            </div>
             <!-- Placeholder for charts -->
             <div id="ga-charts-placeholder" class="mt-2">
                 Chart will appear here.
@@ -69,6 +74,59 @@
         const debugLogsContainer = document.getElementById('debug-logs-container'); // Add this
         const toggleDebugLogs = document.getElementById('toggle-debug-logs'); // Add this
 
+        const gaPauseBtn = document.getElementById('ga-pause-btn');
+        const gaResumeBtn = document.getElementById('ga-resume-btn');
+        const gaCancelBtn = document.getElementById('ga-cancel-btn');
+
+        function updateGaControlButtons(gaStatusString) {
+            const status = gaStatusString ? gaStatusString.toUpperCase() : 'IDLE';
+            if (!gaPauseBtn || !gaResumeBtn || !gaCancelBtn) return; // Buttons not found
+
+            // Default states
+            gaPauseBtn.disabled = true;
+            gaResumeBtn.disabled = true;
+            gaCancelBtn.disabled = true;
+
+            if (status === 'RUNNING') {
+                gaPauseBtn.disabled = false;
+                gaCancelBtn.disabled = false;
+            } else if (status === 'PAUSED') {
+                gaResumeBtn.disabled = false;
+                gaCancelBtn.disabled = false;
+            } else if (status === 'INITIALIZING' || status === 'STOPPING') {
+                // All buttons disabled while initializing or stopping
+                gaCancelBtn.disabled = false; // Allow cancelling if stuck in initializing/stopping
+            }
+            // For IDLE, COMPLETED, STOPPED, ERROR, all remain disabled (default)
+        }
+
+        async function fetchInitialGaStatus() {
+            try {
+                const response = await fetch('/api/ga/status');
+                if (response.ok) {
+                    const statusData = await response.json();
+                    console.log('Initial GA Status:', statusData);
+                    // Update UI elements based on this initial status
+                    gaStatus.textContent = statusData.status || 'N/A';
+                    gaGeneration.textContent = statusData.generation || '-';
+                    gaBestFitness.textContent = statusData.best_fitness ? parseFloat(statusData.best_fitness).toFixed(4) : '-';
+                    if (statusData.agents_used && Array.isArray(statusData.agents_used)) {
+                        gaAgentsUsed.textContent = statusData.agents_used.join(', ') || 'N/A';
+                    } else {
+                        gaAgentsUsed.textContent = 'N/A';
+                    }
+                    gaFittestChromosome.textContent = statusData.fittest_chromosome_string || 'N/A';
+
+                    updateGaControlButtons(statusData.status);
+                } else {
+                    console.error('Failed to fetch initial GA status:', response.status);
+                    updateGaControlButtons('IDLE'); // Assume idle if status fetch fails
+                }
+            } catch (error) {
+                console.error('Error fetching initial GA status:', error);
+                updateGaControlButtons('IDLE'); // Assume idle on error
+            }
+        }
 
         // Determine WebSocket protocol
         const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -187,6 +245,7 @@
                 // Update Fittest Chromosome
                 gaFittestChromosome.textContent = message.data.fittest_chromosome_string || 'N/A';
 
+                updateGaControlButtons(message.data.status); // Update button states based on WS message
                 console.log("GA Update:", message.data);
             } else if (message.type === 'agent_metric_update' && message.data) {
                 const metricsData = message.data;
@@ -246,6 +305,51 @@
             logsContainer.appendChild(closeEntry);
             logsContainer.scrollTop = logsContainer.scrollHeight;
         };
+
+        // Event Listeners for GA Control Buttons
+        if (gaPauseBtn) {
+            gaPauseBtn.addEventListener('click', async () => {
+                try {
+                    const response = await fetch('/api/ga/pause', { method: 'POST' });
+                    const result = await response.json();
+                    console.log('Pause response:', result);
+                    // Optionally, show a small notification here e.g. using a toast library
+                    // UI will update via WebSocket 'ga_update' message
+                } catch (error) {
+                    console.error('Error pausing GA:', error);
+                    // Show error notification
+                }
+            });
+        }
+
+        if (gaResumeBtn) {
+            gaResumeBtn.addEventListener('click', async () => {
+                try {
+                    const response = await fetch('/api/ga/resume', { method: 'POST' });
+                    const result = await response.json();
+                    console.log('Resume response:', result);
+                } catch (error) {
+                    console.error('Error resuming GA:', error);
+                }
+            });
+        }
+
+        if (gaCancelBtn) {
+            gaCancelBtn.addEventListener('click', async () => {
+                try {
+                    const response = await fetch('/api/ga/cancel', { method: 'POST' });
+                    const result = await response.json();
+                    console.log('Cancel response:', result);
+                } catch (error) {
+                    console.error('Error cancelling GA:', error);
+                }
+            });
+        }
+
+        // Set initial state for buttons and fetch initial status
+        updateGaControlButtons('IDLE'); // Set to default disabled state initially
+        fetchInitialGaStatus(); // Fetch current status on load
+
     });
 </script>
 {% endblock %}


### PR DESCRIPTION
This commit introduces functionality to control running Genetic Algorithm experiments (pause, resume, cancel) directly from the dashboard.

Key changes include:

- Modified `GeneticAlgorithmRunner` to register itself as the active runner in `prompthelix.globals` and unregister upon completion.
- Added `active_ga_runner` to `prompthelix.globals`.
- Introduced new API endpoints in `prompthelix.api.routes.py`:
    - `POST /api/ga/pause`: Pauses the current GA experiment.
    - `POST /api/ga/resume`: Resumes a paused GA experiment.
    - `POST /api/ga/cancel`: Cancels the current GA experiment.
    - `GET /api/ga/status`: Retrieves the status of the current GA.
- Defined `GAStatusResponse` Pydantic schema for the status endpoint.
- Updated the dashboard (`prompthelix/templates/dashboard.html`):
    - Added "Pause", "Resume", and "Cancel" buttons to the GA progress section.
    - Implemented JavaScript to:
        - Call the new control API endpoints.
        - Update button states (enabled/disabled) based on real-time GA status received via WebSockets. - Fetch and display the initial GA status on page load.

These changes allow you to interactively manage GA experiments, improving the usability of the PromptHelix platform.