### PR TITLE
Fix: Ensure experiment details display on dashboard

### DIFF
--- a/prompthelix/experiment_runners/ga_runner.py
+++ b/prompthelix/experiment_runners/ga_runner.py
@@ -32,26 +32,6 @@ else:
     logger.info("WebSocketLogHandler already present in ga_runner logger.")
 
 
-# Add the WebSocketLogHandler to the logger instance
-# This setup can be done once when the module is loaded,
-# or specifically when a GeneticAlgorithmRunner is instantiated if preferred.
-# For simplicity, let's add it to the module-level logger.
-# Ensure this part of the code runs when the module is imported.
-
-# Create and configure the WebSocket log handler
-websocket_log_handler = WebSocketLogHandler(connection_manager=websocket_manager)
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(module)s.%(funcName)s:%(lineno)d - %(message)s')
-websocket_log_handler.setFormatter(formatter)
-websocket_log_handler.setLevel(logging.INFO) # Or logging.DEBUG for more verbosity
-
-# Add the handler to the logger
-if not any(isinstance(h, WebSocketLogHandler) for h in logger.handlers):
-    logger.addHandler(websocket_log_handler)
-    logger.info("WebSocketLogHandler added to ga_runner logger.")
-else:
-    logger.info("WebSocketLogHandler already present in ga_runner logger.")
-
-
 class GeneticAlgorithmRunner(BaseExperimentRunner):
     """
     Runs a genetic algorithm experiment for a specified number of generations.

--- a/prompthelix/genetics/engine.py
+++ b/prompthelix/genetics/engine.py
@@ -729,6 +729,8 @@ class PopulationManager:
             "best_fitness": fittest.fitness_score if fittest else None,
             "is_paused": self.is_paused,
             "should_stop": self.should_stop,
+            "agents_used": self.agents_used,
+            "fittest_chromosome_string": fittest.to_prompt_string() if fittest else None
         }
         if additional_data:
             payload.update(additional_data)


### PR DESCRIPTION
This commit addresses an issue where the dashboard was not displaying complete information (specifically 'Agents Used' and 'Fittest Chromosome') when a new experiment was running or during live updates via WebSocket.

Changes:
- Modified `PopulationManager.broadcast_ga_update` in `prompthelix/genetics/engine.py` to include `agents_used` and `fittest_chromosome_string` in the payload sent via WebSocket messages. This ensures that the dashboard receives this data during `ga_update` events.
- Reviewed `dashboard.html` and confirmed its JavaScript logic is already capable of handling and displaying these fields with appropriate fallbacks for initial or null states.
- Removed a duplicate setup block for `WebSocketLogHandler` in `prompthelix/experiment_runners/ga_runner.py` to improve code cleanliness.

With these changes, the dashboard should now correctly populate all relevant GA progress fields when an experiment starts and as it updates.