### PR TITLE
Fix dashboard updates not displaying

### DIFF
--- a/prompthelix/orchestrator.py
+++ b/prompthelix/orchestrator.py
@@ -2,9 +2,7 @@ from prompthelix.message_bus import MessageBus
 import logging
 import time # Added
 from prompthelix.database import SessionLocal # Added
-from prompthelix.websocket_manager import ConnectionManager
-
-websocket_manager = ConnectionManager()
+from prompthelix.globals import websocket_manager  # Use the global connection manager
 from prompthelix.agents.architect import PromptArchitectAgent
 from prompthelix.agents.results_evaluator import ResultsEvaluatorAgent
 from prompthelix.agents.style_optimizer import StyleOptimizerAgent


### PR DESCRIPTION
## Summary
- use the global websocket manager in orchestrator so broadcasts reach the dashboard

## Testing
- `pytest -q` *(fails: RuntimeError: Form data requires "python-multipart" to be installed)*

------
https://chatgpt.com/codex/tasks/task_b_685553dcc79483218132fc880ea1966c