### PR TITLE
Ensure error logging uses both logger and root logger

### DIFF
--- a/prompthelix/agents/architect.py
+++ b/prompthelix/agents/architect.py
@@ -108,10 +108,24 @@ class PromptArchitectAgent(BaseAgent):
             self.templates = self._get_default_templates()
             self.save_knowledge() # Save defaults if file not found
         except json.JSONDecodeError as e:
-            logger.error(f"Agent '{self.agent_id}': Error decoding JSON from '{self.knowledge_file_path}': {e}. Using default templates.", exc_info=True)
+            logger.error(
+                f"Agent '{self.agent_id}': Error decoding JSON from '{self.knowledge_file_path}': {e}. Using default templates.",
+                exc_info=True,
+            )
+            logging.error(
+                f"Agent '{self.agent_id}': Error decoding JSON from '{self.knowledge_file_path}': {e}. Using default templates.",
+                exc_info=True,
+            )
             self.templates = self._get_default_templates()
         except Exception as e:
-            logger.error(f"Agent '{self.agent_id}': Failed to load templates from '{self.knowledge_file_path}': {e}. Using default templates.", exc_info=True)
+            logger.error(
+                f"Agent '{self.agent_id}': Failed to load templates from '{self.knowledge_file_path}': {e}. Using default templates.",
+                exc_info=True,
+            )
+            logging.error(
+                f"Agent '{self.agent_id}': Failed to load templates from '{self.knowledge_file_path}': {e}. Using default templates.",
+                exc_info=True,
+            )
             self.templates = self._get_default_templates()
 
     def save_knowledge(self):

--- a/prompthelix/agents/critic.py
+++ b/prompthelix/agents/critic.py
@@ -46,10 +46,24 @@ class PromptCriticAgent(BaseAgent):
             logger.error(f"Agent '{self.agent_id}': Knowledge file '{effective_path}' not found. No rules will be applied.")
             self.rules = []
         except json.JSONDecodeError as e:
-            logger.error(f"Agent '{self.agent_id}': Error decoding JSON from '{effective_path}': {e}. No rules will be applied.")
+            logger.error(
+                f"Agent '{self.agent_id}': Error decoding JSON from '{effective_path}': {e}. No rules will be applied.",
+                exc_info=True,
+            )
+            logging.error(
+                f"Agent '{self.agent_id}': Error decoding JSON from '{effective_path}': {e}. No rules will be applied.",
+                exc_info=True,
+            )
             self.rules = []
         except Exception as e:
-            logger.error(f"Agent '{self.agent_id}': Failed to load rules from '{effective_path}': {e}. No rules will be applied.", exc_info=True)
+            logger.error(
+                f"Agent '{self.agent_id}': Failed to load rules from '{effective_path}': {e}. No rules will be applied.",
+                exc_info=True,
+            )
+            logging.error(
+                f"Agent '{self.agent_id}': Failed to load rules from '{effective_path}': {e}. No rules will be applied.",
+                exc_info=True,
+            )
             self.rules = []
 
     def process_prompt(self, prompt: str) -> dict:

--- a/prompthelix/agents/domain_expert.py
+++ b/prompthelix/agents/domain_expert.py
@@ -140,10 +140,24 @@ class DomainExpertAgent(BaseAgent):
             self.knowledge_base = self._get_default_knowledge()
             self.save_knowledge()
         except json.JSONDecodeError as e:
-            logger.error(f"Agent '{self.agent_id}': Error decoding JSON from '{self.knowledge_file_path}': {e}. Using default knowledge.", exc_info=True)
+            logger.error(
+                f"Agent '{self.agent_id}': Error decoding JSON from '{self.knowledge_file_path}': {e}. Using default knowledge.",
+                exc_info=True,
+            )
+            logging.error(
+                f"Agent '{self.agent_id}': Error decoding JSON from '{self.knowledge_file_path}': {e}. Using default knowledge.",
+                exc_info=True,
+            )
             self.knowledge_base = self._get_default_knowledge()
         except Exception as e:
-            logger.error(f"Agent '{self.agent_id}': Failed to load knowledge from '{self.knowledge_file_path}': {e}. Using default knowledge.", exc_info=True)
+            logger.error(
+                f"Agent '{self.agent_id}': Failed to load knowledge from '{self.knowledge_file_path}': {e}. Using default knowledge.",
+                exc_info=True,
+            )
+            logging.error(
+                f"Agent '{self.agent_id}': Failed to load knowledge from '{self.knowledge_file_path}': {e}. Using default knowledge.",
+                exc_info=True,
+            )
             self.knowledge_base = self._get_default_knowledge()
 
     def save_knowledge(self):

--- a/prompthelix/agents/meta_learner.py
+++ b/prompthelix/agents/meta_learner.py
@@ -242,15 +242,36 @@ class MetaLearnerAgent(BaseAgent):
             logger.info(f"Agent '{self.agent_id}' successfully loaded and validated knowledge from {self.knowledge_file_path}")
 
         except json.JSONDecodeError as e:
-            logger.error(f"Agent '{self.agent_id}' failed to load knowledge due to JSON decoding error: {e}. Starting with an empty knowledge base.", exc_info=True)
+            logger.error(
+                f"Agent '{self.agent_id}' failed to load knowledge due to JSON decoding error: {e}. Starting with an empty knowledge base.",
+                exc_info=True,
+            )
+            logging.error(
+                f"Agent '{self.agent_id}' failed to load knowledge due to JSON decoding error: {e}. Starting with an empty knowledge base.",
+                exc_info=True,
+            )
             self.knowledge_base = self._default_knowledge_base_structure.copy()
             self.data_log = []
         except IOError as e:
-            logger.error(f"Agent '{self.agent_id}' failed to load knowledge due to IOError: {e}. Starting with an empty knowledge base.", exc_info=True)
+            logger.error(
+                f"Agent '{self.agent_id}' failed to load knowledge due to IOError: {e}. Starting with an empty knowledge base.",
+                exc_info=True,
+            )
+            logging.error(
+                f"Agent '{self.agent_id}' failed to load knowledge due to IOError: {e}. Starting with an empty knowledge base.",
+                exc_info=True,
+            )
             self.knowledge_base = self._default_knowledge_base_structure.copy()
             self.data_log = []
         except Exception as e:
-            logger.error(f"Agent '{self.agent_id}' encountered an unexpected error while loading knowledge: {e}. Starting with an empty knowledge base.", exc_info=True)
+            logger.error(
+                f"Agent '{self.agent_id}' encountered an unexpected error while loading knowledge: {e}. Starting with an empty knowledge base.",
+                exc_info=True,
+            )
+            logging.error(
+                f"Agent '{self.agent_id}' encountered an unexpected error while loading knowledge: {e}. Starting with an empty knowledge base.",
+                exc_info=True,
+            )
             self.knowledge_base = self._default_knowledge_base_structure.copy()
             self.data_log = []
 

--- a/prompthelix/agents/results_evaluator.py
+++ b/prompthelix/agents/results_evaluator.py
@@ -148,10 +148,24 @@ class ResultsEvaluatorAgent(BaseAgent):
             self.evaluation_metrics_config = self._get_default_metrics_config()
             self.save_knowledge() # Save defaults if file not found
         except json.JSONDecodeError as e:
-            logger.error(f"Agent '{self.agent_id}': Error decoding JSON from '{self.knowledge_file_path}': {e}. Using default config.", exc_info=True)
+            logger.error(
+                f"Agent '{self.agent_id}': Error decoding JSON from '{self.knowledge_file_path}': {e}. Using default config.",
+                exc_info=True,
+            )
+            logging.error(
+                f"Agent '{self.agent_id}': Error decoding JSON from '{self.knowledge_file_path}': {e}. Using default config.",
+                exc_info=True,
+            )
             self.evaluation_metrics_config = self._get_default_metrics_config()
         except Exception as e:
-            logger.error(f"Agent '{self.agent_id}': Failed to load metrics config from '{self.knowledge_file_path}': {e}. Using default config.", exc_info=True)
+            logger.error(
+                f"Agent '{self.agent_id}': Failed to load metrics config from '{self.knowledge_file_path}': {e}. Using default config.",
+                exc_info=True,
+            )
+            logging.error(
+                f"Agent '{self.agent_id}': Failed to load metrics config from '{self.knowledge_file_path}': {e}. Using default config.",
+                exc_info=True,
+            )
             self.evaluation_metrics_config = self._get_default_metrics_config()
 
     def save_knowledge(self):

--- a/prompthelix/agents/style_optimizer.py
+++ b/prompthelix/agents/style_optimizer.py
@@ -98,10 +98,24 @@ class StyleOptimizerAgent(BaseAgent):
             self.style_rules = self._get_default_style_rules()
             self.save_knowledge() # Save defaults if file not found
         except json.JSONDecodeError as e:
-            logger.error(f"Agent '{self.agent_id}': Error decoding JSON from '{self.knowledge_file_path}': {e}. Using default rules.", exc_info=True)
+            logger.error(
+                f"Agent '{self.agent_id}': Error decoding JSON from '{self.knowledge_file_path}': {e}. Using default rules.",
+                exc_info=True,
+            )
+            logging.error(
+                f"Agent '{self.agent_id}': Error decoding JSON from '{self.knowledge_file_path}': {e}. Using default rules.",
+                exc_info=True,
+            )
             self.style_rules = self._get_default_style_rules()
         except Exception as e:
-            logger.error(f"Agent '{self.agent_id}': Failed to load style rules from '{self.knowledge_file_path}': {e}. Using default rules.", exc_info=True)
+            logger.error(
+                f"Agent '{self.agent_id}': Failed to load style rules from '{self.knowledge_file_path}': {e}. Using default rules.",
+                exc_info=True,
+            )
+            logging.error(
+                f"Agent '{self.agent_id}': Failed to load style rules from '{self.knowledge_file_path}': {e}. Using default rules.",
+                exc_info=True,
+            )
             self.style_rules = self._get_default_style_rules()
 
     def optimize(self, prompt: str, tone: str = "concise") -> str:


### PR DESCRIPTION
## Summary
- update load_knowledge methods to call both `logger.error` and `logging.error`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: RuntimeError during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68555ff351d08321866dfcd517b5abb4