### PR TITLE
Fix(UI): Update dashboard to handle more GA WebSocket event types

### DIFF
--- a/prompthelix/templates/dashboard.html
+++ b/prompthelix/templates/dashboard.html
@@ -95,6 +95,23 @@
         const gaResumeBtn = document.getElementById('ga-resume-btn');
         const gaCancelBtn = document.getElementById('ga-cancel-btn');
 
+        // Function to handle GA data updates from WebSocket
+        function handleGaDataUpdate(data) {
+            gaStatus.textContent = data.status || 'N/A';
+            updateStatusBadge(gaStatus.textContent);
+            gaGeneration.textContent = data.generation || '-';
+            gaBestFitness.textContent = data.best_fitness ? parseFloat(data.best_fitness).toFixed(4) : '-';
+
+            if (data.agents_used && Array.isArray(data.agents_used)) {
+                gaAgentsUsed.textContent = data.agents_used.join(', ') || 'N/A';
+            } else {
+                gaAgentsUsed.textContent = 'N/A';
+            }
+            gaFittestChromosome.textContent = data.fittest_chromosome_string || 'N/A';
+            updateGaControlButtons(data.status);
+            console.log("GA Data Processed for event type, data:", data); // Modified console log
+        }
+
         function updateStatusBadge(statusText) {
             const statusElement = document.getElementById('ga-status');
             if (!statusElement) return;
@@ -290,25 +307,8 @@
                     debugLogsContainer.appendChild(logEntry);
                     debugLogsContainer.scrollTop = debugLogsContainer.scrollHeight; // Auto-scroll
                 }
-            } else if (message.type === 'ga_update' && message.data) {
-                // Placeholder for GA updates
-                gaStatus.textContent = message.data.status || 'N/A'; // Set text first
-                updateStatusBadge(gaStatus.textContent); // Then update badge based on the new text
-                gaGeneration.textContent = message.data.generation || '-';
-                gaBestFitness.textContent = message.data.best_fitness ? parseFloat(message.data.best_fitness).toFixed(4) : '-';
-
-                // Update Agents Used
-                if (message.data.agents_used && Array.isArray(message.data.agents_used)) {
-                    gaAgentsUsed.textContent = message.data.agents_used.join(', ') || 'N/A';
-                } else {
-                    gaAgentsUsed.textContent = 'N/A';
-                }
-
-                // Update Fittest Chromosome
-                gaFittestChromosome.textContent = message.data.fittest_chromosome_string || 'N/A';
-
-                updateGaControlButtons(message.data.status); // Update button states based on WS message
-                console.log("GA Update:", message.data);
+            } else if ((message.type === 'ga_update' || message.type === 'ga_evaluation_complete' || message.type === 'ga_generation_complete' || message.type === 'ga_status_update') && message.data) {
+                handleGaDataUpdate(message.data);
             } else if (message.type === 'agent_metric_update' && message.data) {
                 const metricsData = message.data;
                 const agentId = metricsData.agent_id;


### PR DESCRIPTION
The dashboard JavaScript was previously only listening for 'ga_update' event type to update Genetic Algorithm progress details like 'Agents Used' and 'Fittest Chromosome'.

This change refactors the GA data handling logic into a new function `handleGaDataUpdate` and modifies the WebSocket `onmessage` handler to call this function for event types 'ga_evaluation_complete', 'ga_generation_complete', and 'ga_status_update', in addition to 'ga_update'. These are the event types actually emitted by the backend (`PopulationManager`) when GA status is updated.

This ensures that the UI correctly reflects real-time updates for all GA progress fields.