### PR TITLE
Add evolution history models

### DIFF
--- a/prompthelix/models/__init__.py
+++ b/prompthelix/models/__init__.py
@@ -5,5 +5,18 @@ from .statistics_models import LLMUsageStatistic # Add this import
 from .user_models import User, Session
 from .performance_models import PerformanceMetric
 from .conversation_models import ConversationLog
+from .evolution_models import GAExperimentRun, GAChromosome
 
-__all__ = ["Base", "Prompt", "PromptVersion", "APIKey", "LLMUsageStatistic", "User", "Session", "PerformanceMetric", "ConversationLog"]
+__all__ = [
+    "Base",
+    "Prompt",
+    "PromptVersion",
+    "APIKey",
+    "LLMUsageStatistic",
+    "User",
+    "Session",
+    "PerformanceMetric",
+    "ConversationLog",
+    "GAExperimentRun",
+    "GAChromosome",
+]

--- a/prompthelix/models/evolution_models.py
+++ b/prompthelix/models/evolution_models.py
@@ -1,0 +1,31 @@
+from sqlalchemy import Column, Integer, DateTime, Float, ForeignKey, String, JSON
+from sqlalchemy.orm import relationship
+from datetime import datetime
+
+from prompthelix.models.base import Base
+
+class GAExperimentRun(Base):
+    __tablename__ = "ga_experiment_runs"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    parameters = Column(JSON, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    completed_at = Column(DateTime, nullable=True)
+    prompt_version_id = Column(Integer, ForeignKey("prompt_versions.id"), nullable=True)
+
+    prompt_version = relationship("PromptVersion")
+    chromosomes = relationship("GAChromosome", back_populates="run", cascade="all, delete-orphan")
+
+class GAChromosome(Base):
+    __tablename__ = "ga_chromosomes"
+
+    id = Column(String, primary_key=True)
+    run_id = Column(Integer, ForeignKey("ga_experiment_runs.id"), nullable=False)
+    generation_number = Column(Integer, nullable=False)
+    genes = Column(JSON, nullable=False)
+    fitness_score = Column(Float, nullable=False)
+    evaluation_details = Column(JSON, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    run = relationship("GAExperimentRun", back_populates="chromosomes")
+

--- a/prompthelix/schemas.py
+++ b/prompthelix/schemas.py
@@ -214,3 +214,41 @@ class GAStatusResponse(BaseModel):
     # Fields from PopulationManager often included in status broadcasts
     is_paused: Optional[bool] = None
     should_stop: Optional[bool] = None
+
+# --- GA Experiment History Schemas ---
+class GAExperimentRunBase(BaseModel):
+    parameters: Optional[Dict[str, Any]] = None
+    completed_at: Optional[datetime] = None
+    prompt_version_id: Optional[int] = None
+
+
+class GAExperimentRunCreate(GAExperimentRunBase):
+    pass
+
+
+class GAExperimentRun(GAExperimentRunBase):
+    id: int
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class GAChromosomeBase(BaseModel):
+    run_id: int
+    generation_number: int
+    genes: List[Any]
+    fitness_score: float
+    evaluation_details: Optional[Dict[str, Any]] = None
+
+
+class GAChromosomeCreate(GAChromosomeBase):
+    id: str
+
+
+class GAChromosome(GAChromosomeBase):
+    id: str
+    created_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/prompthelix/services/__init__.py
+++ b/prompthelix/services/__init__.py
@@ -21,6 +21,12 @@ from .performance_service import (
 
 from .prompt_service import PromptService
 from .prompt_manager import PromptManager
+from .evolution_service import (
+    create_experiment_run,
+    complete_experiment_run,
+    add_chromosome_record,
+    get_chromosomes_for_run,
+)
 
 __all__ = [
     # User service
@@ -43,4 +49,8 @@ __all__ = [
     # Prompt service
     "PromptService",
     "PromptManager",
+    "create_experiment_run",
+    "complete_experiment_run",
+    "add_chromosome_record",
+    "get_chromosomes_for_run",
 ]

--- a/prompthelix/tests/unit/test_evolution_service.py
+++ b/prompthelix/tests/unit/test_evolution_service.py
@@ -1,0 +1,34 @@
+import pytest
+from sqlalchemy.orm import Session as SQLAlchemySession
+
+from prompthelix.services import (
+    create_experiment_run,
+    complete_experiment_run,
+    add_chromosome_record,
+    get_chromosomes_for_run,
+)
+from prompthelix.models.evolution_models import GAExperimentRun, GAChromosome
+from prompthelix.genetics.engine import PromptChromosome
+
+
+def test_create_and_complete_run(db_session: SQLAlchemySession):
+    run = create_experiment_run(db_session, parameters={"p": 1})
+    assert run.id is not None
+    assert run.parameters == {"p": 1}
+    assert run.completed_at is None
+
+    run = complete_experiment_run(db_session, run, prompt_version_id=None)
+    assert run.completed_at is not None
+
+
+def test_add_and_fetch_chromosome(db_session: SQLAlchemySession):
+    run = create_experiment_run(db_session)
+    chromo = PromptChromosome(genes=["a"], fitness_score=0.5)
+    record = add_chromosome_record(db_session, run, generation_number=1, chromosome=chromo)
+    assert record.id == str(chromo.id)
+    assert record.generation_number == 1
+
+    retrieved = get_chromosomes_for_run(db_session, run.id)
+    assert len(retrieved) == 1
+    assert retrieved[0].id == str(chromo.id)
+


### PR DESCRIPTION
## Summary
- support recording GA experiment runs and chromosomes
- expose helper functions for GA history in service package
- test storing evolution run data

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError, OperationalError, AssertionError)*

------
https://chatgpt.com/codex/tasks/task_b_6855679df80083219caa46c9d8dfeb3e