### PR TITLE
Update GA endpoint instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,11 +248,19 @@ PromptHelix also provides an API endpoint to trigger the genetic algorithm.
     ```
 
 2.  **Access the GA endpoint**:
-    Once the server is running, you can trigger the genetic algorithm by sending a GET request to the `/api/experiments/run-ga` endpoint. For example, using `curl`:
+    Once the server is running, you can trigger the genetic algorithm by sending a POST request to the `/api/experiments/run-ga` endpoint. The body must contain JSON matching `GAExperimentParams` with required fields like `task_description`, `keywords`, `num_generations`, `population_size`, and `elitism_count`.
     ```bash
-    curl http://127.0.0.1:8000/api/experiments/run-ga
+    curl -X POST http://127.0.0.1:8000/api/experiments/run-ga \
+      -H "Content-Type: application/json" \
+      -d '{
+        "task_description": "Generate a marketing slogan",
+        "keywords": ["creative", "short"],
+        "num_generations": 10,
+        "population_size": 20,
+        "elitism_count": 2
+      }'
     ```
-    Or you can open `http://127.0.0.1:8000/api/experiments/run-ga` in your web browser.
+    You can also send this POST request using a REST client in your web browser.
 
 3.  **Try the Prompt Manager UI**:
     The Prompt Manager UI, for adding and viewing prompts, can be accessed as described in the "Setup and Run the Web UI" section.


### PR DESCRIPTION
## Summary
- clarify that running GA via API is a POST request
- include example `curl -X POST` with JSON body

## Testing
- `python -m prompthelix.cli test` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_68556c47051883219f507be221e04f21