### PR TITLE
Add basic agent unit tests

### DIFF
--- a/tests/unit/test_architect_agent.py
+++ b/tests/unit/test_architect_agent.py
@@ -1,0 +1,48 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from prompthelix.agents.architect import PromptArchitectAgent
+from prompthelix.genetics.engine import PromptChromosome
+
+class TestPromptArchitectAgent(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.kfile = os.path.join(self.tmpdir.name, "arch.json")
+        self.agent = PromptArchitectAgent(knowledge_file_path=self.kfile)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_initialization_creates_file(self):
+        self.assertTrue(os.path.exists(self.kfile))
+        self.assertTrue(self.agent.templates)
+
+    def test_save_and_load(self):
+        self.agent.templates["new"] = {"instruction": "i", "context_placeholder": "c", "output_format": "o"}
+        self.agent.save_knowledge()
+        other = PromptArchitectAgent(knowledge_file_path=self.kfile)
+        self.assertIn("new", other.templates)
+
+    @patch("prompthelix.agents.architect.call_llm_api")
+    def test_process_request_success(self, mock_call):
+        mock_call.side_effect = [
+            "parsed",  # _parse_requirements
+            "generic_v1",  # _select_template
+            "Gene1\nGene2"  # _populate_genes
+        ]
+        req = {"task_description": "do something", "keywords": ["x"], "constraints": {}}
+        chromo = self.agent.process_request(req)
+        self.assertIsInstance(chromo, PromptChromosome)
+        self.assertEqual(chromo.genes, ["Gene1", "Gene2"])
+
+    @patch("prompthelix.agents.architect.call_llm_api", side_effect=Exception("fail"))
+    def test_process_request_fallback(self, mock_call):
+        req = {"task_description": "summarize text", "keywords": ["x"], "constraints": {}}
+        chromo = self.agent.process_request(req)
+        self.assertIsInstance(chromo, PromptChromosome)
+        self.assertTrue(len(chromo.genes) > 0)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_domain_expert_agent.py
+++ b/tests/unit/test_domain_expert_agent.py
@@ -1,0 +1,41 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from prompthelix.agents.domain_expert import DomainExpertAgent
+
+class TestDomainExpertAgent(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.kfile = os.path.join(self.tmpdir.name, "domain.json")
+        self.agent = DomainExpertAgent(knowledge_file_path=self.kfile)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_initialization_creates_file(self):
+        self.assertTrue(os.path.exists(self.kfile))
+        self.assertTrue(self.agent.knowledge_base)
+
+    def test_save_and_load(self):
+        self.agent.knowledge_base["new"] = {"keywords": ["a"]}
+        self.agent.save_knowledge()
+        other = DomainExpertAgent(knowledge_file_path=self.kfile)
+        self.assertIn("new", other.knowledge_base)
+
+    @patch("prompthelix.agents.domain_expert.call_llm_api")
+    def test_process_request_success(self, mock_call):
+        mock_call.return_value = '["kw1","kw2"]'
+        result = self.agent.process_request({"domain": "medical", "query_type": "keywords"})
+        self.assertEqual(result["source"], "llm")
+        self.assertEqual(result["data"], ["kw1", "kw2"])
+
+    @patch("prompthelix.agents.domain_expert.call_llm_api", side_effect=Exception("fail"))
+    def test_process_request_fallback(self, mock_call):
+        result = self.agent.process_request({"domain": "medical", "query_type": "keywords"})
+        self.assertEqual(result["source"], "knowledge_base")
+        self.assertTrue(len(result["data"]) > 0)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_meta_learner_agent.py
+++ b/tests/unit/test_meta_learner_agent.py
@@ -1,0 +1,38 @@
+import os
+import tempfile
+import unittest
+
+from prompthelix.agents.meta_learner import MetaLearnerAgent
+from prompthelix.genetics.engine import PromptChromosome
+
+class TestMetaLearnerAgent(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.kfile = os.path.join(self.tmpdir.name, "meta.json")
+        self.agent = MetaLearnerAgent(knowledge_file_path=self.kfile)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_initialization_creates_file(self):
+        self.assertTrue(os.path.exists(self.kfile))
+        self.assertTrue(self.agent.knowledge_base)
+
+    def test_save_and_load(self):
+        self.agent.knowledge_base["legacy_successful_patterns"].append("p")
+        self.agent.save_knowledge()
+        other = MetaLearnerAgent(knowledge_file_path=self.kfile)
+        self.assertIn("p", other.knowledge_base["legacy_successful_patterns"])
+
+    def test_process_request_success(self):
+        data = {"data_type": "evaluation_result", "data": {"prompt_chromosome": PromptChromosome(genes=["g1"]), "fitness_score": 0.8}}
+        result = self.agent.process_request(data)
+        self.assertEqual(result["status"], "Data processed successfully.")
+        self.assertIsInstance(result["recommendations"], list)
+
+    def test_process_request_missing(self):
+        result = self.agent.process_request({})
+        self.assertEqual(result["status"], "Error: Missing data_type or data.")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_results_evaluator_agent.py
+++ b/tests/unit/test_results_evaluator_agent.py
@@ -1,0 +1,43 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from prompthelix.agents.results_evaluator import ResultsEvaluatorAgent
+from prompthelix.genetics.engine import PromptChromosome
+
+class TestResultsEvaluatorAgent(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.kfile = os.path.join(self.tmpdir.name, "eval.json")
+        self.agent = ResultsEvaluatorAgent(knowledge_file_path=self.kfile)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_initialization_creates_file(self):
+        self.assertTrue(os.path.exists(self.kfile))
+        self.assertTrue(self.agent.evaluation_metrics_config)
+
+    def test_save_and_load(self):
+        self.agent.evaluation_metrics_config["new"] = ["a"]
+        self.agent.save_knowledge()
+        other = ResultsEvaluatorAgent(knowledge_file_path=self.kfile)
+        self.assertIn("new", other.evaluation_metrics_config)
+
+    @patch("prompthelix.agents.results_evaluator.call_llm_api")
+    def test_process_request_success(self, mock_call):
+        mock_call.return_value = '{"relevance_score":0.8,"coherence_score":0.9,"completeness_score":0.7,"accuracy_assessment":"ok","safety_score":1.0,"overall_quality_score":0.9,"feedback_text":"good"}'
+        chromo = PromptChromosome(genes=["g1"])
+        result = self.agent.process_request({"prompt_chromosome": chromo, "llm_output": "output", "task_description": "task"})
+        self.assertIsInstance(result["fitness_score"], float)
+        self.assertEqual(result["detailed_metrics"].get("llm_analysis_status"), "success")
+
+    @patch("prompthelix.agents.results_evaluator.call_llm_api", side_effect=Exception("fail"))
+    def test_process_request_fallback(self, mock_call):
+        chromo = PromptChromosome(genes=["g1"])
+        result = self.agent.process_request({"prompt_chromosome": chromo, "llm_output": "output", "task_description": "task"})
+        self.assertEqual(result["detailed_metrics"].get("llm_analysis_status"), "fallback_due_to_error")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_style_optimizer_agent.py
+++ b/tests/unit/test_style_optimizer_agent.py
@@ -1,0 +1,44 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from prompthelix.agents.style_optimizer import StyleOptimizerAgent
+from prompthelix.genetics.engine import PromptChromosome
+
+class TestStyleOptimizerAgent(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.kfile = os.path.join(self.tmpdir.name, "style.json")
+        self.agent = StyleOptimizerAgent(knowledge_file_path=self.kfile)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_initialization_creates_file(self):
+        self.assertTrue(os.path.exists(self.kfile))
+        self.assertTrue(self.agent.style_rules)
+
+    def test_save_and_load(self):
+        self.agent.style_rules["test"] = {"replace": {"a": "b"}}
+        self.agent.save_knowledge()
+        other = StyleOptimizerAgent(knowledge_file_path=self.kfile)
+        self.assertIn("test", other.style_rules)
+
+    @patch("prompthelix.agents.style_optimizer.call_llm_api")
+    def test_process_request_success(self, mock_call):
+        mock_call.return_value = '["s1","s2"]'
+        original = PromptChromosome(genes=["g1", "g2"])
+        result = self.agent.process_request({"prompt_chromosome": original, "target_style": "formal"})
+        self.assertIsInstance(result, PromptChromosome)
+        self.assertEqual(result.genes, ["s1", "s2"])
+
+    @patch("prompthelix.agents.style_optimizer.call_llm_api", side_effect=Exception("fail"))
+    def test_process_request_fallback(self, mock_call):
+        original = PromptChromosome(genes=["don't do stuff", "Context"])
+        result = self.agent.process_request({"prompt_chromosome": original, "target_style": "formal"})
+        self.assertIsInstance(result, PromptChromosome)
+        self.assertTrue(len(result.genes) > 0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- create unit tests for architect, style optimizer, domain expert, results evaluator and meta learner agents
- tests cover initialization, knowledge persistence and simple request processing

## Testing
- `python -m unittest discover tests/unit` *(fails: ImportError: cannot import name 'PromptChromosome' from partially initialized module)*

------
https://chatgpt.com/codex/tasks/task_b_68556bf05eb083218304ce04b8a32335