### PR TITLE
Forward prompt and LLM settings

### DIFF
--- a/prompthelix/orchestrator.py
+++ b/prompthelix/orchestrator.py
@@ -150,7 +150,8 @@ def main_ga_loop(
 
     fitness_eval = FitnessEvaluator(
         results_evaluator_agent=results_evaluator,
-        execution_mode=execution_mode
+        execution_mode=execution_mode,
+        llm_settings=current_llm_settings,
     )
     # TODO: FitnessEvaluator needs to be updated to accept and use llm_settings.
 
@@ -162,6 +163,7 @@ def main_ga_loop(
         elitism_count=elitism_count,
         parallel_workers=parallel_workers,
         population_path=actual_population_path, # Use determined path
+        initial_prompt_str=initial_prompt_str,
         message_bus=message_bus, # Added
         agents_used=agent_names # Pass the collected agent names/IDs
         # TODO: Pass agent_settings_override or specific agent configs if PopulationManager


### PR DESCRIPTION
## Summary
- pass `current_llm_settings` to `FitnessEvaluator`
- forward `initial_prompt_str` to `PopulationManager`
- verify new parameters in orchestrator unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy', several test failures)*

------
https://chatgpt.com/codex/tasks/task_b_68556bc7ec7c8321b7da8f2b7cb6ca80