### PR TITLE
Fix GA prompt seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ python -m prompthelix.cli run ga [options]
 
 This command runs the Genetic Algorithm. It supports various options to customize the GA run, including providing an initial seed prompt, setting GA parameters (generations, population size), overriding agent and LLM configurations, and specifying an output file for the best prompt.
 
+If you pass a value via the `--prompt` option, the text you supply becomes the first chromosome of the initial generation. This allows you to start the GA from a known prompt rather than generating all prompts randomly.
+
 For a detailed list of all `run ga` options and usage examples, please refer to the [CLI Documentation in `prompthelix/docs/README.md`](prompthelix/docs/README.md#run-command).
 
 ### Checking LLM Connectivity

--- a/prompthelix/docs/README.md
+++ b/prompthelix/docs/README.md
@@ -85,7 +85,7 @@ If `module_name` is omitted, it defaults to `ga`.
 The following options are available when running the Genetic Algorithm (`python -m prompthelix.cli run ga`):
 
 *   `module`: (Optional) The name of the module to run. Defaults to `ga`.
-*   `--prompt "<string>`: (Optional) Provide an initial custom prompt string to seed the first generation of the GA.
+*   `--prompt "<string>`: (Optional) Provide an initial custom prompt string to seed the first generation of the GA. The given text becomes the first chromosome before any prompts are randomly generated.
 *   `--task-description "<string>"`: (Optional) A detailed description of the task the generated prompts should accomplish. This helps guide the GA.
 *   `--keywords <word1> <word2> ...`: (Optional) A list of keywords relevant to the task. These can be used by agents to focus prompt generation.
 *   `--num-generations <integer>`: (Optional) The number of generations the GA should run for.

--- a/prompthelix/orchestrator.py
+++ b/prompthelix/orchestrator.py
@@ -157,13 +157,14 @@ def main_ga_loop(
     pop_manager = PopulationManager(
         genetic_operators=genetic_ops,
         fitness_evaluator=fitness_eval,
-        prompt_architect_agent=prompt_architect, # Architect is used for initial prompt generation
+        prompt_architect_agent=prompt_architect,  # Architect is used for initial prompt generation
         population_size=population_size,
         elitism_count=elitism_count,
+        population_path=actual_population_path,  # Use determined path
+        initial_prompt_str=initial_prompt_str,
         parallel_workers=parallel_workers,
-        population_path=actual_population_path, # Use determined path
-        message_bus=message_bus, # Added
-        agents_used=agent_names # Pass the collected agent names/IDs
+        message_bus=message_bus,  # Added
+        agents_used=agent_names  # Pass the collected agent names/IDs
         # TODO: Pass agent_settings_override or specific agent configs if PopulationManager
         # is responsible for creating/configuring more agents during its operations.
         # For now, agents are configured above.


### PR DESCRIPTION
## Summary
- ensure `main_ga_loop` passes initial prompt to `PopulationManager`
- clarify seeding behaviour of `--prompt` in CLI docs

## Testing
- `python -m prompthelix.cli test` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_68556bc986908321b2d2af29da767f64