### PR TITLE
Add GA population path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Execute the following command from the root of the project:
 python -m prompthelix.cli run ga [options]
 ```
 
-This command runs the Genetic Algorithm. It supports various options to customize the GA run, including providing an initial seed prompt, setting GA parameters (generations, population size), overriding agent and LLM configurations, and specifying an output file for the best prompt.
+This command runs the Genetic Algorithm. It supports various options to customize the GA run, including providing an initial seed prompt, setting GA parameters (generations, population size), overriding agent and LLM configurations, specifying an output file for the best prompt, and defining where the population should be persisted.
 
 For a detailed list of all `run ga` options and usage examples, please refer to the [CLI Documentation in `prompthelix/docs/README.md`](prompthelix/docs/README.md#run-command).
 

--- a/prompthelix/cli.py
+++ b/prompthelix/cli.py
@@ -54,6 +54,8 @@ def main_cli():
     run_parser.add_argument("--parallel-workers", type=int, default=None, help="Number of parallel workers for fitness evaluation. 1 for serial execution. Default: None (uses os.cpu_count() or similar).")
     run_parser.add_argument("--population-size", type=int, help="Population size for the GA.")
     run_parser.add_argument("--elitism-count", type=int, help="Elitism count for the GA.")
+    run_parser.add_argument("--population-path", type=str,
+                            help="File path to load/save GA population state.")
     run_parser.add_argument("--output-file", type=str, help="File path to save the best prompt.")
     run_parser.add_argument("--agent-settings", type=str, help="JSON string or file path to override agent configurations.")
     run_parser.add_argument("--llm-settings", type=str, help="JSON string or file path to override LLM utility settings.")
@@ -213,6 +215,7 @@ def main_cli():
                     initial_prompt_str=initial_prompt_str,
                     agent_settings_override=agent_settings_override,
                     llm_settings_override=llm_settings_override,
+                    population_path=args.population_path,
                     parallel_workers=args.parallel_workers, # Pass the new argument
                     return_best=True
                 )

--- a/prompthelix/docs/README.md
+++ b/prompthelix/docs/README.md
@@ -96,6 +96,7 @@ The following options are available when running the Genetic Algorithm (`python 
     *   *JSON Format*: The JSON should be a dictionary where keys are agent class names (e.g., "PromptArchitectAgent") and values are dictionaries of settings for that agent. Example: `'{"PromptArchitectAgent": {"default_llm_model": "gpt-4o-mini"}}'`
 *   `--llm-settings <json_string_or_filepath>`: (Optional) Override default LLM utility settings (e.g., timeouts, API keys if applicable). This can be a direct JSON string or a path to a JSON file.
     *   *JSON Format*: The JSON should be a dictionary of LLM parameters. Example: `'{"default_timeout": 120, "temperature": 0.8}'`
+*   `--population-path <filepath>`: (Optional) Path to load or save the GA population. Defaults to the configuration value if omitted.
 *   `--execution-mode <TEST|REAL>`: (Optional) Set the execution mode. `TEST` mode uses mock LLM calls and is faster. `REAL` mode makes actual calls to configured LLM providers. Defaults to `TEST`.
 
 **Examples for `run ga`:**


### PR DESCRIPTION
## Summary
- extend `run ga` CLI with `--population-path`
- wire the option to `main_ga_loop`
- document the option in the READMEs
- test CLI with the new option

## Testing
- `pytest prompthelix/tests/test_cli.py::TestCli::test_run_ga_with_population_path -q`

------
https://chatgpt.com/codex/tasks/task_b_68556bc87a408321b454d59858f2d41d