### PR TITLE
Enable agent settings overrides via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ The application requires certain environment variables to be set, especially for
 *   `GOOGLE_API_KEY`: Your API key for Google AI services.
 *   `DATABASE_URL`: The connection string for your database (e.g., `postgresql://user:password@host:port/database` for PostgreSQL, or `sqlite:///./prompthelix.db` for SQLite).
 
+**Agent Overrides:**
+
+Environment variables can also override default agent settings. Use the pattern `<AGENTNAME>_<SETTING>` where `AGENTNAME` is the agent class name without the `Agent` suffix. Example overrides include:
+
+* `PROMPTARCHITECT_DEFAULT_LLM_MODEL`
+* `METALEARNER_PERSIST_KNOWLEDGE_ON_UPDATE`
+* `RESULTSEVALUATOR_FITNESS_SCORE_WEIGHTS` (as a JSON string)
+
 **Setting Environment Variables:**
 
 You can set these variables in a few ways:

--- a/prompthelix/agents/architect.py
+++ b/prompthelix/agents/architect.py
@@ -9,11 +9,7 @@ from typing import Optional, Dict # Added for type hinting
 
 logger = logging.getLogger(__name__)
 
-# Default provider from config if specific agent setting is not found
-# These fallbacks can be used if settings dict doesn't provide them.
-DEFAULT_ARCHITECT_SETTINGS = AGENT_SETTINGS.get("PromptArchitectAgent", {})
-FALLBACK_LLM_PROVIDER = DEFAULT_ARCHITECT_SETTINGS.get("default_llm_provider", "openai")
-FALLBACK_LLM_MODEL = DEFAULT_ARCHITECT_SETTINGS.get("default_llm_model", "gpt-3.5-turbo")
+# Default knowledge filename if nothing else is provided
 FALLBACK_KNOWLEDGE_FILE = "architect_knowledge.json"
 
 
@@ -38,9 +34,14 @@ class PromptArchitectAgent(BaseAgent):
         """
         super().__init__(agent_id=self.agent_id, message_bus=message_bus, settings=settings)
 
+        # Load defaults from global AGENT_SETTINGS in case settings dict is missing keys
+        global_defaults = AGENT_SETTINGS.get("PromptArchitectAgent", {})
+        llm_provider_default = global_defaults.get("default_llm_provider", "openai")
+        llm_model_default = global_defaults.get("default_llm_model", "gpt-3.5-turbo")
+
         # Configuration values will now be sourced from self.settings, with fallbacks
-        self.llm_provider = self.settings.get("default_llm_provider", FALLBACK_LLM_PROVIDER)
-        self.llm_model = self.settings.get("default_llm_model", FALLBACK_LLM_MODEL)
+        self.llm_provider = self.settings.get("default_llm_provider", llm_provider_default)
+        self.llm_model = self.settings.get("default_llm_model", llm_model_default)
 
         # knowledge_file_path can be overridden by settings, then by direct param, then fallback
         _knowledge_file = self.settings.get("knowledge_file_path", knowledge_file_path)

--- a/prompthelix/agents/domain_expert.py
+++ b/prompthelix/agents/domain_expert.py
@@ -7,9 +7,7 @@ import os
 
 logger = logging.getLogger(__name__)
 
-# Default provider from config if specific agent setting is not found
-FALLBACK_LLM_PROVIDER = AGENT_SETTINGS.get("DomainExpertAgent", {}).get("default_llm_provider", "openai")
-FALLBACK_LLM_MODEL = AGENT_SETTINGS.get("DomainExpertAgent", {}).get("default_llm_model", "gpt-3.5-turbo")
+# Default provider fallbacks will be resolved during initialization
 
 # Known error strings returned by call_llm_api indicating the call failed
 LLM_API_ERROR_STRINGS = {
@@ -52,8 +50,10 @@ class DomainExpertAgent(BaseAgent):
         os.makedirs(os.path.dirname(self.knowledge_file_path), exist_ok=True)
 
         agent_config = AGENT_SETTINGS.get(self.agent_id, {})
-        self.llm_provider = agent_config.get("default_llm_provider", FALLBACK_LLM_PROVIDER)
-        self.llm_model = agent_config.get("default_llm_model", FALLBACK_LLM_MODEL)
+        llm_provider_default = agent_config.get("default_llm_provider", "openai")
+        llm_model_default = agent_config.get("default_llm_model", "gpt-3.5-turbo")
+        self.llm_provider = llm_provider_default
+        self.llm_model = llm_model_default
         logger.info(f"Agent '{self.agent_id}' initialized with LLM provider: {self.llm_provider} and model: {self.llm_model}")
 
         self.knowledge_base = {} # Initialize before loading

--- a/prompthelix/agents/meta_learner.py
+++ b/prompthelix/agents/meta_learner.py
@@ -9,9 +9,7 @@ from prompthelix.config import AGENT_SETTINGS, KNOWLEDGE_DIR # Import new config
 
 logger = logging.getLogger(__name__)
 
-# Default provider from config if specific agent setting is not found
-# However, agent-specific settings should ideally cover this.
-FALLBACK_LLM_PROVIDER = AGENT_SETTINGS.get("MetaLearnerAgent", {}).get("default_llm_provider", "openai")
+# Default file name and persist flag; other defaults are resolved during initialization
 DEFAULT_KNOWLEDGE_FILENAME = AGENT_SETTINGS.get("MetaLearnerAgent", {}).get("knowledge_file_path", "meta_learner_knowledge_fallback.json")
 PERSIST_ON_UPDATE_DEFAULT = AGENT_SETTINGS.get("MetaLearnerAgent", {}).get("persist_knowledge_on_update", True)
 
@@ -37,8 +35,9 @@ class MetaLearnerAgent(BaseAgent):
         super().__init__(agent_id="MetaLearner", message_bus=message_bus)
 
         agent_config = AGENT_SETTINGS.get(self.agent_id, {})
-        self.llm_provider = agent_config.get("default_llm_provider", FALLBACK_LLM_PROVIDER)
-        self.llm_model = agent_config.get("default_llm_model") # Used by call_llm_api if no model is passed
+        llm_provider_default = agent_config.get("default_llm_provider", "openai")
+        self.llm_provider = llm_provider_default
+        self.llm_model = agent_config.get("default_llm_model")  # Used by call_llm_api if no model is passed
 
         _knowledge_filename = knowledge_file_path if knowledge_file_path else agent_config.get("knowledge_file_path", DEFAULT_KNOWLEDGE_FILENAME)
         # Ensure KNOWLEDGE_DIR exists for storing the knowledge file

--- a/prompthelix/agents/results_evaluator.py
+++ b/prompthelix/agents/results_evaluator.py
@@ -12,14 +12,7 @@ from typing import Optional, Dict # Added for type hinting
 
 logger = logging.getLogger(__name__)
 
-# Default values from global AGENT_SETTINGS or hardcoded fallbacks
-DEFAULT_EVALUATOR_SETTINGS = AGENT_SETTINGS.get("ResultsEvaluatorAgent", {})
-FALLBACK_LLM_PROVIDER = DEFAULT_EVALUATOR_SETTINGS.get("default_llm_provider", "openai")
-FALLBACK_EVAL_MODEL = DEFAULT_EVALUATOR_SETTINGS.get("evaluation_llm_model", "gpt-3.5-turbo")
-FALLBACK_FITNESS_WEIGHTS = DEFAULT_EVALUATOR_SETTINGS.get(
-    "fitness_score_weights",
-    {"constraint_adherence": 0.5, "llm_quality_assessment": 0.5}
-)
+# Default knowledge filename if nothing else is provided
 FALLBACK_KNOWLEDGE_FILE = "results_evaluator_config.json"
 
 
@@ -44,9 +37,17 @@ class ResultsEvaluatorAgent(BaseAgent):
         super().__init__(agent_id="ResultsEvaluator", message_bus=message_bus, settings=settings)
 
         # Core LLM and fitness settings
-        self.llm_provider = self.settings.get("default_llm_provider", FALLBACK_LLM_PROVIDER)
-        self.evaluation_llm_model = self.settings.get("evaluation_llm_model", FALLBACK_EVAL_MODEL)
-        self.fitness_score_weights = self.settings.get("fitness_score_weights", FALLBACK_FITNESS_WEIGHTS)
+        global_defaults = AGENT_SETTINGS.get("ResultsEvaluatorAgent", {})
+        llm_provider_default = global_defaults.get("default_llm_provider", "openai")
+        eval_model_default = global_defaults.get("evaluation_llm_model", "gpt-3.5-turbo")
+        fitness_default = global_defaults.get(
+            "fitness_score_weights",
+            {"constraint_adherence": 0.5, "llm_quality_assessment": 0.5},
+        )
+
+        self.llm_provider = self.settings.get("default_llm_provider", llm_provider_default)
+        self.evaluation_llm_model = self.settings.get("evaluation_llm_model", eval_model_default)
+        self.fitness_score_weights = self.settings.get("fitness_score_weights", fitness_default)
 
         # Determine knowledge file path, preferring explicit arg, then settings, then fallback
         _kfp = knowledge_file_path or self.settings.get("knowledge_file_path")

--- a/prompthelix/agents/style_optimizer.py
+++ b/prompthelix/agents/style_optimizer.py
@@ -9,10 +9,7 @@ from typing import Optional, Dict # Added for type hinting
 
 logger = logging.getLogger(__name__)
 
-# Default values from global AGENT_SETTINGS or hardcoded fallbacks
-DEFAULT_OPTIMIZER_SETTINGS = AGENT_SETTINGS.get("StyleOptimizerAgent", {})
-FALLBACK_LLM_PROVIDER = DEFAULT_OPTIMIZER_SETTINGS.get("default_llm_provider", "openai")
-FALLBACK_LLM_MODEL = DEFAULT_OPTIMIZER_SETTINGS.get("default_llm_model", "gpt-3.5-turbo")
+# Default knowledge filename if nothing else is provided
 FALLBACK_KNOWLEDGE_FILE = "style_optimizer_rules.json"
 
 
@@ -36,8 +33,12 @@ class StyleOptimizerAgent(BaseAgent):
         """
         super().__init__(agent_id="StyleOptimizer", message_bus=message_bus, settings=settings)
 
-        self.llm_provider = self.settings.get("default_llm_provider", FALLBACK_LLM_PROVIDER)
-        self.llm_model = self.settings.get("default_llm_model", FALLBACK_LLM_MODEL)
+        global_defaults = AGENT_SETTINGS.get("StyleOptimizerAgent", {})
+        llm_provider_default = global_defaults.get("default_llm_provider", "openai")
+        llm_model_default = global_defaults.get("default_llm_model", "gpt-3.5-turbo")
+
+        self.llm_provider = self.settings.get("default_llm_provider", llm_provider_default)
+        self.llm_model = self.settings.get("default_llm_model", llm_model_default)
 
         _knowledge_file = self.settings.get("knowledge_file_path", knowledge_file_path)
         if _knowledge_file:

--- a/prompthelix/tests/unit/test_config.py
+++ b/prompthelix/tests/unit/test_config.py
@@ -98,5 +98,34 @@ class TestConfigSettings(unittest.TestCase):
             importlib.reload(config)
             self.assertIsInstance(config.settings.DEFAULT_SAVE_POPULATION_FREQUENCY, int)
 
+    def test_agent_setting_env_override(self):
+        """Environment variable should override agent defaults."""
+        with patch.dict(os.environ, {"PROMPTARCHITECT_DEFAULT_LLM_MODEL": "env-model"}, clear=True):
+            importlib.reload(config)
+            self.assertEqual(
+                config.AGENT_SETTINGS["PromptArchitectAgent"]["default_llm_model"],
+                "env-model",
+            )
+
+    def test_agent_setting_json_override(self):
+        """JSON environment variables should be parsed for complex settings."""
+        weights_json = '{"constraint_adherence": 0.1, "llm_quality_assessment": 0.9}'
+        with patch.dict(
+            os.environ,
+            {
+                "RESULTSEVALUATOR_FITNESS_SCORE_WEIGHTS": weights_json,
+                "METALEARNER_PERSIST_KNOWLEDGE_ON_UPDATE": "false",
+            },
+            clear=True,
+        ):
+            importlib.reload(config)
+            self.assertEqual(
+                config.AGENT_SETTINGS["ResultsEvaluatorAgent"]["fitness_score_weights"],
+                {"constraint_adherence": 0.1, "llm_quality_assessment": 0.9},
+            )
+            self.assertFalse(
+                config.AGENT_SETTINGS["MetaLearnerAgent"]["persist_knowledge_on_update"]
+            )
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- support environment variable overrides for per-agent settings
- document agent override variables
- load agent defaults at initialization time for all agents
- test env var overrides for agent settings

## Testing
- `pytest prompthelix/tests/unit/test_config.py::TestConfigSettings::test_agent_setting_env_override prompthelix/tests/unit/test_config.py::TestConfigSettings::test_agent_setting_json_override -q`
- `pytest -q` *(fails: OperationalError: no such table: users)*

------
https://chatgpt.com/codex/tasks/task_b_68556bf20b008321a4a6db113e2a27a6