### PR TITLE
Fix API request instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,11 +248,12 @@ PromptHelix also provides an API endpoint to trigger the genetic algorithm.
     ```
 
 2.  **Access the GA endpoint**:
-    Once the server is running, you can trigger the genetic algorithm by sending a GET request to the `/api/experiments/run-ga` endpoint. For example, using `curl`:
+    Once the server is running, trigger the genetic algorithm by sending a **POST** request to the `/api/experiments/run-ga` endpoint. Example command:
     ```bash
-    curl http://127.0.0.1:8000/api/experiments/run-ga
+    curl -X POST http://127.0.0.1:8000/api/experiments/run-ga \
+         -H "Content-Type: application/json" \
+         -d '{"task_description":"Example","keywords":["demo"],"execution_mode":"TEST"}'
     ```
-    Or you can open `http://127.0.0.1:8000/api/experiments/run-ga` in your web browser.
 
 3.  **Try the Prompt Manager UI**:
     The Prompt Manager UI, for adding and viewing prompts, can be accessed as described in the "Setup and Run the Web UI" section.


### PR DESCRIPTION
## Summary
- fix the HTTP verb for the GA endpoint example
- add JSON example body in README

## Testing
- `pytest -q` *(fails: RuntimeWarning: coroutine 'ConnectionManager.broadcast_json' was never awaited; 4 failed, 15 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68556c49181c832197c038fc149b1701