### PR TITLE
Add parallel worker option docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,13 @@ python -m prompthelix.cli run ga [options]
 
 This command runs the Genetic Algorithm. It supports various options to customize the GA run, including providing an initial seed prompt, setting GA parameters (generations, population size), overriding agent and LLM configurations, and specifying an output file for the best prompt.
 
+* `--parallel-workers <integer>`: Number of parallel workers used for fitness evaluation. Set to `1` for serial execution. By default, all available CPU cores are used.
+
+Example:
+```bash
+python -m prompthelix.cli run ga --parallel-workers 4
+```
+
 For a detailed list of all `run ga` options and usage examples, please refer to the [CLI Documentation in `prompthelix/docs/README.md`](prompthelix/docs/README.md#run-command).
 
 ### Checking LLM Connectivity

--- a/prompthelix/docs/README.md
+++ b/prompthelix/docs/README.md
@@ -89,6 +89,7 @@ The following options are available when running the Genetic Algorithm (`python 
 *   `--task-description "<string>"`: (Optional) A detailed description of the task the generated prompts should accomplish. This helps guide the GA.
 *   `--keywords <word1> <word2> ...`: (Optional) A list of keywords relevant to the task. These can be used by agents to focus prompt generation.
 *   `--num-generations <integer>`: (Optional) The number of generations the GA should run for.
+*   `--parallel-workers <integer>`: (Optional) Number of parallel workers used for fitness evaluation. Use `1` for serial execution. Default uses available CPU cores.
 *   `--population-size <integer>`: (Optional) The number of prompts (chromosomes) in each generation.
 *   `--elitism-count <integer>`: (Optional) The number of the best prompts from one generation to carry over directly to the next.
 *   `--output-file <filepath>`: (Optional) Specify a file path to save the best prompt found by the GA at the end of the run.
@@ -123,6 +124,10 @@ The following options are available when running the Genetic Algorithm (`python 
 *   Run GA in `REAL` mode (ensure API keys are set):
     ```bash
     python -m prompthelix.cli run ga --execution-mode REAL --prompt "A real test with an LLM."
+    ```
+*   Run GA with multiple parallel workers:
+    ```bash
+    python -m prompthelix.cli run ga --parallel-workers 4
     ```
 
 ### LLM Connectivity Test


### PR DESCRIPTION
## Summary
- document `--parallel-workers` option in `run ga` instructions
- show usage in examples for `run ga`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: sqlite ProgrammingError)*

------
https://chatgpt.com/codex/tasks/task_b_68556c4746248321b97e47dc3cce26a9