### PR TITLE
Fix setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You can set these variables in a few ways:
 1.  **Clone the repository:**
     ```bash
     git clone <repository_url> # Replace <repository_url> with the actual URL later if known, otherwise leave as placeholder
-    cd prompthelix
+    cd PromptHelix
     ```
 2.  **Create and activate a virtual environment:**
     ```bash


### PR DESCRIPTION
## Summary
- fix capitalization for `cd` step in README

## Testing
- `python -m prompthelix.cli test` *(fails: ModuleNotFoundError and failures)*

------
https://chatgpt.com/codex/tasks/task_b_685571073ef08321abdcb9aa50f8aa38