### PR TITLE
Improve CLI robustness and restore missing service module

### DIFF
--- a/prompthelix/cli.py
+++ b/prompthelix/cli.py
@@ -10,7 +10,13 @@ import sys
 import os
 import unittest
 import logging # Added for logging configuration
-import openai # Added for openai.RateLimitError
+try:
+    import openai  # Used for catching openai.RateLimitError during GA runs
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    class _DummyRateLimitError(Exception):
+        pass
+
+    openai = type("openai", (), {"RateLimitError": _DummyRateLimitError})()
 import json # For parsing settings overrides
 
 logger = logging.getLogger(__name__)

--- a/prompthelix/orchestrator.py
+++ b/prompthelix/orchestrator.py
@@ -164,8 +164,6 @@ def main_ga_loop(
         population_path=actual_population_path,  # Use determined path
         initial_prompt_str=initial_prompt_str,
         parallel_workers=parallel_workers,
-        population_path=actual_population_path, # Use determined path
-        initial_prompt_str=initial_prompt_str,
         message_bus=message_bus, # Added
         agents_used=agent_names # Pass the collected agent names/IDs
 

--- a/prompthelix/services/prompt_manager.py
+++ b/prompthelix/services/prompt_manager.py
@@ -1,0 +1,20 @@
+import uuid
+from typing import Dict, List, Optional
+
+class PromptManager:
+    """Simple in-memory manager for storing prompts."""
+
+    def __init__(self) -> None:
+        self._prompts: Dict[str, str] = {}
+
+    def add_prompt(self, content: str) -> dict:
+        prompt_id = str(uuid.uuid4())
+        self._prompts[prompt_id] = content
+        return {"id": prompt_id, "content": content}
+
+    def get_prompt(self, prompt_id: str) -> Optional[str]:
+        return self._prompts.get(prompt_id)
+
+    def list_prompts(self) -> List[dict]:
+        return [{"id": pid, "content": content} for pid, content in self._prompts.items()]
+


### PR DESCRIPTION
## Summary
- add fallback when `openai` package is missing so CLI can start
- remove duplicate parameters in orchestrator's PopulationManager call
- implement simple in-memory `PromptManager` used by tests

## Testing
- `pip install -r requirements.txt`
- `python -m prompthelix.cli test` *(fails: 57 failures, 25 errors)*

------
https://chatgpt.com/codex/tasks/task_b_68557131811c8321b9e3f7d93eddf2c2