### PR TITLE
Fix async broadcasting scheduling

### DIFF
--- a/prompthelix/message_bus.py
+++ b/prompthelix/message_bus.py
@@ -115,16 +115,9 @@ class MessageBus:
             }
             try:
                 loop = asyncio.get_running_loop()
-                if loop.is_running():
-                    loop.create_task(self._broadcast_log_async(log_data))
-                else:
-                    loop.run_until_complete(self._broadcast_log_async(log_data))
+                asyncio.create_task(self._broadcast_log_async(log_data))
             except RuntimeError:
-                loop = asyncio.new_event_loop()
-                try:
-                    loop.run_until_complete(self._broadcast_log_async(log_data))
-                finally:
-                    loop.close()
+                asyncio.run(self._broadcast_log_async(log_data))
 
     def register(self, agent_id: str, agent_instance):
         """Registers an agent instance with the message bus.

--- a/prompthelix/tests/unit/test_message_bus_broadcasting.py
+++ b/prompthelix/tests/unit/test_message_bus_broadcasting.py
@@ -14,7 +14,7 @@ class TestMessageBusBroadcasting(unittest.TestCase):
         self.mock_connection_manager = AsyncMock() # Use AsyncMock if its methods are async
         self.mock_connection_manager.broadcast_json = AsyncMock()
 
-    @patch('asyncio.create_task') # Patch asyncio.create_task
+    @patch('asyncio.create_task')  # Patch asyncio.create_task
     def test_log_message_to_db_with_connection_manager_creates_broadcast_task(self, mock_create_task):
         bus = MessageBus(
             db_session_factory=self.mock_db_session_factory,
@@ -26,13 +26,17 @@ class TestMessageBusBroadcasting(unittest.TestCase):
         self.mock_db_session_factory.return_value = mock_session
 
         test_payload = {"key": "value"}
-        bus._log_message_to_db(
-            session_id="test_session",
-            sender_id="sender_agent",
-            recipient_id="recipient_agent",
-            message_type="test_type",
-            content_payload=test_payload
-        )
+
+        async def runner():
+            bus._log_message_to_db(
+                session_id="test_session",
+                sender_id="sender_agent",
+                recipient_id="recipient_agent",
+                message_type="test_type",
+                content_payload=test_payload
+            )
+
+        asyncio.run(runner())
 
         # Assert that asyncio.create_task was called
         mock_create_task.assert_called_once()


### PR DESCRIPTION
## Summary
- standardize how conversation logs trigger websocket broadcasts
- run log dispatch tests inside an async loop to ensure create_task is called

## Testing
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_b_68558406bd0083219054ee4909252fe8