### PR TITLE
Add docker compose file for Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ DATABASE_URL=sqlite:///./prompthelix.db
 
 # --- Redis Configuration ---
 # Used for caching and as Celery broker/backend by default.
-REDIS_HOST=localhost
+REDIS_HOST=localhost  # Use 'redis' when running via docker-compose
 REDIS_PORT=6379
 REDIS_DB=0 # Default DB for general Redis client (e.g., caching)
 # REDIS_PASSWORD= # Optional: If your Redis instance requires a password

--- a/README.md
+++ b/README.md
@@ -178,6 +178,26 @@ You can deploy PromptHelix using Docker or by setting it up manually in a produc
     ```
     *Ensure your `.env` file has the correct `DATABASE_URL` for your production database if you use this method.*
 
+#### Docker Compose with Redis
+
+The repository includes a `docker-compose.yaml` that runs both the application and a Redis instance. This is the easiest way to start everything together.
+
+1.  **Copy the example environment file:**
+    ```bash
+    cp .env.example .env
+    ```
+    Edit `.env` as needed. When using Docker Compose, set `REDIS_HOST=redis`.
+
+2.  **Build and start the services:**
+    ```bash
+    docker compose up --build
+    ```
+    This builds the application image and starts the FastAPI app on port `8000` and Redis on port `6379`.
+
+3.  **Access the application:**
+    The API and UI will be available at [http://localhost:8000](http://localhost:8000).
+
+
 ### Manual Deployment
 
 For a manual production setup, consider the following steps:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,19 @@
+version: '3.9'
+services:
+  app:
+    build: .
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    environment:
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      CELERY_BROKER_URL: redis://redis:6379/1
+      CELERY_RESULT_BACKEND_URL: redis://redis:6379/2
+    depends_on:
+      - redis
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
## Summary
- add Docker Compose with Redis service
- document Docker Compose usage and mention Redis host setting
- hint in `.env.example` about container host name for Redis

## Testing
- `pip install -r requirements.txt`
- `python -m prompthelix.cli test` *(fails: CLI: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_b_685586475324832191dd307a36250362