### PR TITLE
Add CRUD service tests and CLI unit tests

### DIFF
--- a/tests/service/test_conversation_service_crud.py
+++ b/tests/service/test_conversation_service_crud.py
@@ -1,0 +1,44 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from datetime import datetime
+
+from prompthelix.models.base import Base
+from prompthelix.models.conversation_models import ConversationLog
+from prompthelix.services.conversation_service import ConversationService
+
+@pytest.fixture()
+def db():
+    engine = create_engine('sqlite:///:memory:')
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def test_conversation_crud(db):
+    service = ConversationService()
+    log1 = ConversationLog(session_id='s1', sender_id='a', recipient_id='b', message_type='t', content='m1', timestamp=datetime.utcnow())
+    log2 = ConversationLog(session_id='s1', sender_id='b', recipient_id='a', message_type='t', content='m2', timestamp=datetime.utcnow())
+    db.add_all([log1, log2])
+    db.commit()
+
+    sessions = service.get_conversation_sessions(db)
+    assert sessions[0].session_id == 's1'
+    assert sessions[0].message_count == 2
+
+    messages = service.get_messages_by_session_id(db, 's1')
+    assert len(messages) == 2
+
+    log1.content = 'm1-upd'
+    db.commit()
+    messages = service.get_messages_by_session_id(db, 's1')
+    assert messages[0].content == 'm1-upd'
+
+    db.delete(log1)
+    db.commit()
+    messages = service.get_messages_by_session_id(db, 's1')
+    assert len(messages) == 1

--- a/tests/service/test_performance_service_crud.py
+++ b/tests/service/test_performance_service_crud.py
@@ -1,0 +1,44 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from prompthelix.models.base import Base
+from prompthelix.services import performance_service, user_service
+from prompthelix.services.prompt_service import PromptService
+from prompthelix.schemas import (
+    UserCreate,
+    PromptCreate,
+    PromptVersionCreate,
+    PerformanceMetricCreate,
+    PerformanceMetricUpdate,
+)
+
+@pytest.fixture()
+def db():
+    engine = create_engine('sqlite:///:memory:')
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def test_performance_crud(db):
+    user = user_service.create_user(db, UserCreate(username='u', email='u@e.com', password='pw'))
+    pservice = PromptService()
+    prompt = pservice.create_prompt(db, PromptCreate(name='p', description='d'), user.id)
+    version = pservice.create_prompt_version(db, prompt.id, PromptVersionCreate(content='c'))
+
+    metric = performance_service.record_performance_metric(db, PerformanceMetricCreate(prompt_version_id=version.id, metric_name='acc', metric_value=0.5))
+    assert metric.id is not None
+
+    fetched = performance_service.get_performance_metric(db, metric.id)
+    assert fetched.metric_value == 0.5
+
+    updated = performance_service.update_performance_metric(db, metric.id, PerformanceMetricUpdate(metric_value=0.6))
+    assert updated.metric_value == 0.6
+
+    assert performance_service.delete_performance_metric(db, metric.id) is True
+    assert performance_service.get_performance_metric(db, metric.id) is None

--- a/tests/service/test_prompt_service_crud.py
+++ b/tests/service/test_prompt_service_crud.py
@@ -1,0 +1,52 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from prompthelix.models.base import Base
+from prompthelix.services.prompt_service import PromptService
+from prompthelix.services import user_service
+from prompthelix.schemas import (
+    PromptCreate, PromptUpdate,
+    PromptVersionCreate, PromptVersionUpdate,
+    UserCreate
+)
+
+@pytest.fixture()
+def db():
+    engine = create_engine('sqlite:///:memory:')
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def test_prompt_crud(db):
+    user = user_service.create_user(db, UserCreate(username='u1', email='u1@e.com', password='pw'))
+    service = PromptService()
+
+    prompt = service.create_prompt(db, PromptCreate(name='p1', description='d'), user.id)
+    assert prompt.id is not None
+
+    fetched = service.get_prompt(db, prompt.id)
+    assert fetched.name == 'p1'
+
+    updated = service.update_prompt(db, prompt.id, PromptUpdate(name='p2'))
+    assert updated.name == 'p2'
+
+    version = service.create_prompt_version(db, prompt.id, PromptVersionCreate(content='c'))
+    assert version.id is not None
+
+    v_fetched = service.get_prompt_version(db, version.id)
+    assert v_fetched.content == 'c'
+
+    v_updated = service.update_prompt_version(db, version.id, PromptVersionUpdate(content='c2'))
+    assert v_updated.content == 'c2'
+
+    assert service.delete_prompt_version(db, version.id)
+    assert service.get_prompt_version(db, version.id) is None
+
+    assert service.delete_prompt(db, prompt.id)
+    assert service.get_prompt(db, prompt.id) is None

--- a/tests/service/test_user_service_crud.py
+++ b/tests/service/test_user_service_crud.py
@@ -1,0 +1,37 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from prompthelix.models.base import Base
+from prompthelix.services import user_service
+from prompthelix.schemas import UserCreate, UserUpdate
+
+@pytest.fixture()
+def db():
+    engine = create_engine('sqlite:///:memory:')
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def test_user_crud(db):
+    user_in = UserCreate(username='alice', email='a@example.com', password='pw')
+    user = user_service.create_user(db, user_in)
+    assert user.id is not None
+
+    fetched = user_service.get_user(db, user.id)
+    assert fetched.email == 'a@example.com'
+
+    updated = user_service.update_user(db, user.id, UserUpdate(email='b@example.com'))
+    assert updated.email == 'b@example.com'
+
+    session_model = user_service.create_session(db, user.id, expires_delta_minutes=1)
+    token = session_model.session_token
+    assert user_service.get_session_by_token(db, token)
+
+    assert user_service.delete_session(db, token) is True
+    assert user_service.get_session_by_token(db, token) is None

--- a/tests/test_cli_monkeypatch.py
+++ b/tests/test_cli_monkeypatch.py
@@ -1,0 +1,47 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from prompthelix import cli
+
+
+def run_cli(args, monkeypatch):
+    exit_code = None
+    monkeypatch.setattr(sys, "argv", ["prompthelix"] + args)
+    try:
+        cli.main_cli()
+    except SystemExit as e:
+        exit_code = e.code
+    return exit_code
+
+
+def test_cli_test_command(monkeypatch, capsys):
+    mock_loader = MagicMock()
+    mock_runner = MagicMock()
+    mock_result = MagicMock()
+    mock_result.wasSuccessful.return_value = True
+    mock_runner.run.return_value = mock_result
+    monkeypatch.setattr(cli, "unittest", SimpleNamespace(TestLoader=lambda: mock_loader, TextTestRunner=lambda verbosity: mock_runner))
+    mock_loader.discover.return_value = "suite"
+    exit_code = run_cli(["test"], monkeypatch)
+    captured = capsys.readouterr().out
+    assert exit_code == 0
+    assert "CLI: Running all tests..." in captured
+
+
+def test_cli_run_command(monkeypatch, capsys):
+    mock_loop = MagicMock(return_value=SimpleNamespace(fitness_score=1.0, to_prompt_string=lambda: "best"))
+    monkeypatch.setattr("prompthelix.orchestrator.main_ga_loop", mock_loop)
+    exit_code = run_cli(["run", "ga"], monkeypatch)
+    captured = capsys.readouterr().out
+    assert exit_code is None or exit_code == 0
+    assert "Best prompt fitness" in captured
+
+
+def test_cli_check_llm(monkeypatch, capsys):
+    from prompthelix.utils import llm_utils
+    monkeypatch.setattr(llm_utils, "call_llm_api", MagicMock(return_value="ok"))
+    exit_code = run_cli(["check-llm"], monkeypatch)
+    captured = capsys.readouterr().out
+    assert exit_code is None or exit_code == 0
+    assert "ok" in captured


### PR DESCRIPTION
## Summary
- test CRUD operations for user, prompt, performance, and conversation services using in-memory SQLite
- add CLI tests using monkeypatch for `test`, `run`, and `check-llm` commands

## Testing
- `pytest tests/service tests/test_cli_monkeypatch.py -q`

------
https://chatgpt.com/codex/tasks/task_b_685589deb9cc83219d6d9f81c799d805