### PR TITLE
Convert prompt endpoints test to pytest

### DIFF
--- a/prompthelix/tests/test_prompt_endpoints.py
+++ b/prompthelix/tests/test_prompt_endpoints.py
@@ -1,25 +1,28 @@
-import unittest
+import pytest
 from fastapi.testclient import TestClient
-from prompthelix.main import app
+from sqlalchemy.orm import Session as SQLAlchemySession
 
-class TestPromptEndpoints(unittest.TestCase):
-    def setUp(self):
-        self.client = TestClient(app)
+from prompthelix.tests.utils import get_auth_headers
+from prompthelix.schemas import Prompt
 
-    def test_create_and_list_prompts(self):
-        payload = {"name": "Test Prompt from unittest", "description": "hello"}
-        create_resp = self.client.post("/api/prompts", json=payload)
-        self.assertEqual(create_resp.status_code, 200, create_resp.text) # Added response text for debugging
-        data = create_resp.json()
-        self.assertIn("id", data)
-        self.assertEqual(data["name"], payload["name"])
-        self.assertEqual(data["description"], payload["description"])
 
-        list_resp = self.client.get("/api/prompts")
-        self.assertEqual(list_resp.status_code, 200, list_resp.text) # Added response text
-        listing = list_resp.json()
-        # The endpoint returns a list of prompts directly
-        self.assertTrue(any(p["id"] == data["id"] and p["name"] == payload["name"] for p in listing))
+def test_create_and_list_prompts(client: TestClient, db_session: SQLAlchemySession):
+    payload = {"name": "Test Prompt from pytest", "description": "hello"}
+    auth_headers = get_auth_headers(client, db_session)
 
-if __name__ == '__main__':
-    unittest.main()
+    create_resp = client.post("/api/prompts", json=payload, headers=auth_headers)
+    assert create_resp.status_code == 200, create_resp.text
+    data = create_resp.json()
+    created_prompt = Prompt.model_validate(data)
+    assert created_prompt.name == payload["name"]
+    assert created_prompt.description == payload["description"]
+
+    list_resp = client.get("/api/prompts", headers=auth_headers)
+    assert list_resp.status_code == 200, list_resp.text
+    listing = list_resp.json()
+
+    assert any(
+        Prompt.model_validate(p).id == created_prompt.id and p["name"] == payload["name"]
+        for p in listing
+    )
+


### PR DESCRIPTION
## Summary
- convert the old unittest-based prompt endpoints test to pytest
- use existing `client` and `db_session` fixtures
- authenticate using `get_auth_headers`
- validate API output with the `Prompt` schema

## Testing
- `pytest prompthelix/tests/test_prompt_endpoints.py -q`

------
https://chatgpt.com/codex/tasks/task_b_685589e6ef34832183e9fc0f7affe297