### PR TITLE
Implement GA population persistence CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ python -m prompthelix.cli run ga [options]
 This command runs the Genetic Algorithm. It supports various options to customize the GA run, including providing an initial seed prompt, setting GA parameters (generations, population size), overriding agent and LLM configurations, specifying an output file for the best prompt, and defining where the population should be persisted.
 
 * `--parallel-workers <integer>`: Number of parallel workers used for fitness evaluation. Set to `1` for serial execution. By default, all available CPU cores are used.
+* `--population-file <filepath>`: File path for persisting the GA population. Use this to resume runs or inspect populations. (`--population-path` is a synonym.)
 
 Example:
 ```bash

--- a/prompthelix/cli.py
+++ b/prompthelix/cli.py
@@ -62,6 +62,12 @@ def main_cli():
     run_parser.add_argument("--elitism-count", type=int, help="Elitism count for the GA.")
     run_parser.add_argument("--population-path", type=str,
                             help="File path to load/save GA population state.")
+    run_parser.add_argument(
+        "--population-file",
+        type=str,
+        dest="population_path",
+        help="Alias for --population-path. File to load/save GA population state.",
+    )
     run_parser.add_argument("--output-file", type=str, help="File path to save the best prompt.")
     run_parser.add_argument("--agent-settings", type=str, help="JSON string or file path to override agent configurations.")
     run_parser.add_argument("--llm-settings", type=str, help="JSON string or file path to override LLM utility settings.")

--- a/tests/test_engine_population_manager_persistence.py
+++ b/tests/test_engine_population_manager_persistence.py
@@ -1,0 +1,56 @@
+import os
+import json
+import tempfile
+import unittest
+from prompthelix.genetics.engine import PopulationManager, PromptChromosome, GeneticOperators, FitnessEvaluator
+from prompthelix.agents.architect import PromptArchitectAgent
+from prompthelix.agents.results_evaluator import ResultsEvaluatorAgent
+from prompthelix.enums import ExecutionMode
+from prompthelix.genetics.mutation_strategies import NoOperationMutationStrategy
+
+class DummyResultsEvaluator(ResultsEvaluatorAgent):
+    def __init__(self, **kwargs):
+        super().__init__(settings={'knowledge_file_path': 'dummy.json'}, **kwargs)
+    def process_request(self, request_data: dict) -> dict:
+        return {'fitness_score': 0.5, 'detailed_metrics': {}, 'llm_analysis_status': 'ok', 'llm_assessment_feedback': 'ok'}
+
+class DummyPromptArchitect(PromptArchitectAgent):
+    def __init__(self):
+        super().__init__(settings={'knowledge_file_path': 'dummy.json'})
+    def process_request(self, request_data: dict) -> PromptChromosome:
+        return PromptChromosome(genes=['dummy'])
+
+class PersistenceTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.tmpdir.name, 'pop.json')
+        gen_ops = GeneticOperators(style_optimizer_agent=None, mutation_strategies=[NoOperationMutationStrategy()])
+        evaluator = DummyResultsEvaluator()
+        self.fitness = FitnessEvaluator(results_evaluator_agent=evaluator, execution_mode=ExecutionMode.TEST)
+        self.architect = DummyPromptArchitect()
+        self.gen_ops = gen_ops
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_save_and_load_roundtrip(self):
+        pm = PopulationManager(self.gen_ops, self.fitness, self.architect, population_size=2)
+        pm.population = [PromptChromosome(genes=['a'], fitness_score=0.1), PromptChromosome(genes=['b'], fitness_score=0.2)]
+        pm.generation_number = 3
+        pm.save_population(self.path)
+        self.assertTrue(os.path.exists(self.path))
+        pm2 = PopulationManager(self.gen_ops, self.fitness, self.architect, population_size=10)
+        pm2.load_population(self.path)
+        self.assertEqual(pm2.generation_number, 3)
+        self.assertEqual(len(pm2.population), 2)
+        self.assertEqual(pm2.population_size, 2)
+        self.assertEqual(pm2.population[0].genes, ['a'])
+
+    def test_load_nonexistent_file(self):
+        pm = PopulationManager(self.gen_ops, self.fitness, self.architect, population_size=2)
+        missing = os.path.join(self.tmpdir.name, 'missing.json')
+        pm.load_population(missing)
+        self.assertEqual(pm.generation_number, 0)
+        self.assertEqual(pm.population, [])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `--population-file` alias option for GA runs
- document persistence option in README
- provide unit tests for `PopulationManager` persistence methods

## Testing
- `pytest tests/test_engine_population_manager_persistence.py -q`

------
https://chatgpt.com/codex/tasks/task_b_685592331cc483218d3c7cd9b59f964c