### PR TITLE
Add GA analytics dashboard docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ AI prompts through innovative techniques inspired by genetic algorithms and mult
         *   Displays messages for a selected session, ordered by timestamp.
         *   Shows sender ID, recipient ID (or "BROADCAST"), message type, full timestamp, and the message content.
         *   Attempts to pretty-print JSON content within messages for readability.
+*   **GA Analytics Dashboard**:
+    *   **Access**: Visit the `/ui/dashboard` route while the server is running.
+    *   **Features**:
+        *   Real-time metrics and logs streamed via WebSockets.
+        *   Line chart visualizing max, mean, and min fitness across generations.
+        *   Agent metrics and conversation events are displayed to show how interactions influence GA evolution.
 *   Performance tracking and evaluation of prompts
 *   API for programmatic access and integration
 *   User interface for managing and experimenting with prompts (basic HTML interface available)

--- a/prompthelix/docs/genetic_algorithm.md
+++ b/prompthelix/docs/genetic_algorithm.md
@@ -87,3 +87,15 @@ The GA engine is designed to leverage the specialized capabilities of other agen
     -   The `GeneticOperators.mutate()` method includes a conceptual hook for a "smart" mutation. This placeholder (`style_optimization_placeholder`) indicates where the `StyleOptimizerAgent` could be called to perform more intelligent, context-aware mutations on individual genes or entire prompts, rather than just random character changes. This integration is planned for future development.
 
 Other agents like `PromptCriticAgent` and `DomainExpertAgent` are not directly called within the core GA loop as currently implemented in `engine.py` but are intended to be used by the `ResultsEvaluatorAgent` or potentially by more advanced versions of the `PromptArchitectAgent` or `FitnessEvaluator` to inform their processes. The `MetaLearnerAgent` would consume data produced by the GA run (fitness scores, successful prompts) to adapt strategies over time.
+
+## GA Analytics Dashboard
+
+PromptHelix includes a web-based dashboard for observing GA runs in real time. After starting the FastAPI server with `uvicorn prompthelix.main:app --reload`, navigate to [http://127.0.0.1:8000/ui/dashboard](http://127.0.0.1:8000/ui/dashboard).
+
+The dashboard streams status updates over WebSockets and displays:
+
+* A line chart tracking max, mean, and min fitness across generations so you can see convergence.
+* Live agent metrics such as messages processed and errors encountered.
+* A feed of conversation log events, making it easier to relate agent dialogues to changes in fitness.
+
+You can open the separate Conversation Log viewer at `/ui/conversations` for a focused look at past exchanges.


### PR DESCRIPTION
## Summary
- describe new GA Analytics Dashboard in README
- document `/ui/dashboard` and the fitness chart in GA docs

## Testing
- `python -m prompthelix.cli test` *(fails: some tests fail)*

------
https://chatgpt.com/codex/tasks/task_b_685596f3a9808321a76132fdaa217093