### PR TITLE
Add interactive and oauth2 tests; update TODO

### DIFF
--- a/prompthelix/TODO.md
+++ b/prompthelix/TODO.md
@@ -5,4 +5,4 @@ General improvements for the `prompthelix` package.
 - [ ] Split modules into smaller packages where appropriate
 - [ ] Enforce consistent logging across modules
 - [ ] Provide configuration for enabling/disabling debug output
-- [ ] Clean up placeholder scripts in `tests/interactive` and `tests/oauth2`
+- [x] Clean up placeholder scripts in `tests/interactive` and `tests/oauth2`

--- a/tests/interactive/test_websocket_manager.py
+++ b/tests/interactive/test_websocket_manager.py
@@ -1,0 +1,29 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from prompthelix.websocket_manager import ConnectionManager
+
+
+@pytest.mark.asyncio
+async def test_connect_and_disconnect():
+    manager = ConnectionManager()
+    ws = AsyncMock()
+    await manager.connect(ws)
+    assert ws in manager.active_connections
+    manager.disconnect(ws)
+    assert ws not in manager.active_connections
+
+
+@pytest.mark.asyncio
+async def test_send_and_broadcast():
+    manager = ConnectionManager()
+    ws1 = AsyncMock()
+    ws2 = AsyncMock()
+    await manager.connect(ws1)
+    await manager.connect(ws2)
+    await manager.send_personal_message('hi', ws1)
+    await manager.broadcast('hello')
+
+    ws1.send_text.assert_any_await('hi')
+    ws1.send_text.assert_any_await('hello')
+    ws2.send_text.assert_awaited_with('hello')

--- a/tests/oauth2/test_dependencies.py
+++ b/tests/oauth2/test_dependencies.py
@@ -1,0 +1,35 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from fastapi import HTTPException
+
+from prompthelix.models.base import Base
+from prompthelix.schemas import UserCreate
+from prompthelix.services import user_service
+from prompthelix.api.dependencies import get_current_user
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine('sqlite:///:memory:')
+    Base.metadata.create_all(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_valid(db_session):
+    user = user_service.create_user(db_session, UserCreate(username='bob', email='bob@example.com', password='pw'))
+    session_model = user_service.create_session(db_session, user.id, expires_delta_minutes=10)
+    result = await get_current_user(token=session_model.session_token, db=db_session)
+    assert result.id == user.id
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_invalid_token(db_session):
+    with pytest.raises(HTTPException):
+        await get_current_user(token='badtoken', db=db_session)


### PR DESCRIPTION
## Summary
- add tests covering websocket manager behaviors
- add basic oauth2 dependency tests
- check off completed TODO

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: 116 failed, 363 passed, 6 skipped, 1 error)*

------
https://chatgpt.com/codex/tasks/task_b_6855970e2bac832191a69e7b392ccb7e