### PR TITLE
Add interactive pytest utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,3 +329,19 @@ python -m prompthelix.cli test --path tests/unit/test_architect_agent.py
 
 The output will show the progress of the tests and a summary of the results.
 
+
+### Interactive Tests
+
+Some tests require manual input from a user. These tests live in `tests/interactive/` and are skipped automatically when no TTY is available. To run them directly with pytest:
+
+```bash
+pytest tests/interactive -s
+```
+
+You can also invoke them through the PromptHelix CLI:
+
+```bash
+python -m prompthelix.cli interactive
+```
+
+Use `--path` to run a specific interactive test module if needed.

--- a/prompthelix/cli.py
+++ b/prompthelix/cli.py
@@ -82,6 +82,16 @@ def main_cli():
     check_parser.add_argument("--provider", default="openai", help="LLM provider name")
     check_parser.add_argument("--model", help="Model name for the provider")
 
+    # "interactive" command for running interactive pytest sessions
+    interactive_parser = subparsers.add_parser(
+        "interactive", help="Run interactive tests that require user input"
+    )
+    interactive_parser.add_argument(
+        "--path",
+        "-p",
+        help="Optional directory or file containing interactive tests",
+    )
+
 
     args = parser.parse_args()
 
@@ -298,6 +308,19 @@ def main_cli():
             logging.exception("CLI: LLM connectivity check failed")
             print(f"CLI: Failed to contact {args.provider}: {e}", file=sys.stderr)
             sys.exit(1)
+
+    elif args.command == "interactive":
+        try:
+            import pytest
+        except ImportError:
+            print("pytest is required for interactive tests", file=sys.stderr)
+            sys.exit(1)
+
+        project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        target = args.path if args.path else os.path.join(project_root, "tests", "interactive")
+        print(f"CLI: Running interactive tests from {target}...")
+        exit_code = pytest.main([target, "-s"])
+        sys.exit(exit_code)
 
     # No specific action needed for --version as argparse handles it
     elif hasattr(args, 'version') and args.version:

--- a/tests/interactive/interactive_runner.py
+++ b/tests/interactive/interactive_runner.py
@@ -1,0 +1,20 @@
+import sys
+import pytest
+
+
+def is_interactive() -> bool:
+    """Return True if the session is connected to a TTY."""
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def require_interactive():
+    """Skip the calling test when not running interactively."""
+    if not is_interactive():
+        pytest.skip("Interactive test skipped: no TTY available")
+
+
+def prompt_user(text: str, default: str | None = None) -> str | None:
+    """Prompt the user for input if interactive, otherwise return ``default``."""
+    if not is_interactive():
+        return default
+    return input(text)

--- a/tests/interactive/test_basic_flow.py
+++ b/tests/interactive/test_basic_flow.py
@@ -1,0 +1,9 @@
+from .interactive_runner import require_interactive, prompt_user
+
+
+def test_basic_flow():
+    """Simple interactive check requiring the user to confirm input."""
+    require_interactive()
+    answer = prompt_user("Type 'ok' to pass this test: ")
+    assert answer is not None
+    assert answer.strip().lower() == "ok"


### PR DESCRIPTION
## Summary
- add new `interactive_runner` helper for interactive pytest runs
- implement a sample interactive test in `tests/interactive`
- support interactive tests via new `interactive` CLI command
- document running interactive tests in README

## Testing
- `pip install -r requirements.txt`
- `pytest tests/interactive/test_basic_flow.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68559715167483218d5ac7d55a023e8f