### PR TITLE
Update textstat and setuptools versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ anthropic
 google-generativeai
 python-dotenv
 passlib==1.7.4
-textstat>=0.7.4
-setuptools>=68
+textstat>=0.7.7
+setuptools>=80
 bcrypt


### PR DESCRIPTION
## Summary
- ensure textstat works on Python 3.12 by using the latest version
- bump setuptools to avoid pkgutil.ImpImporter error

## Testing
- `python -m prompthelix.cli test` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_b_68562792b6348321b216dfefcd81bc9b