### PR TITLE
Fix trailing slash for settings UI and broken nav link

### DIFF
--- a/prompthelix/templates/base.html
+++ b/prompthelix/templates/base.html
@@ -15,7 +15,7 @@
             <li><a href="{{ url_for('create_prompt_ui_form') }}">Create New Prompt</a></li>
             <li><a href="{{ url_for('run_experiment_ui_form') }}">Run New Experiment</a></li>
             <li><a href="{{ request.url_for('llm_playground_ui') }}">LLM Playground</a></li>
-            <li><a href="{{ url_for('ui_tests') }}">Tests</a></li>
+            <li><a href="{{ url_for('ui_list_tests') }}">Tests</a></li>
             <li><a href="{{ url_for('ui_dashboard') }}">Dashboard</a></li>
             <li><a href="{{ url_for('ui_list_tests') }}">Interactive Tests</a></li>
             <li><a href="{{ url_for('view_settings_ui') }}">Settings</a></li>

--- a/prompthelix/ui_routes.py
+++ b/prompthelix/ui_routes.py
@@ -310,6 +310,7 @@ async def view_prompt_ui(request: Request, prompt_id: int, db: Session = Depends
     )
 
 @router.get("/ui/settings", name="view_settings_ui")
+@router.get("/ui/settings/", name="view_settings_ui_alt")
 async def view_settings_ui(
     request: Request,
     db: Session = Depends(get_db),


### PR DESCRIPTION
## Summary
- allow `/ui/settings/` route
- fix navigation link in `base.html`

## Testing
- `ruff check prompthelix/ui_routes.py`
- `pytest -q prompthelix/tests/test_ui_routes.py prompthelix/tests/test_ui_settings.py` *(fails: 4 failed, 4 passed, 28 warnings, 1 error)*

------
https://chatgpt.com/codex/tasks/task_b_68562b19ba348321949038d8719a865e