### PR TITLE
Add GA history chart features

### DIFF
--- a/prompthelix/main.py
+++ b/prompthelix/main.py
@@ -83,6 +83,11 @@ async def websocket_dashboard_endpoint(websocket: WebSocket):
     WebSocket endpoint for dashboard real-time updates.
     """
     await websocket_manager.connect(websocket)
+    try:
+        from prompthelix import globals as ph_globals
+        await websocket_manager.send_personal_json({"type": "ga_history", "data": ph_globals.ga_history}, websocket)
+    except Exception as e:  # pragma: no cover - simple log
+        print(f"Failed to send GA history: {e}")
     await websocket_manager.broadcast_json({"message": "A new client has connected!"})
     try:
         while True:

--- a/prompthelix/templates/dashboard.html
+++ b/prompthelix/templates/dashboard.html
@@ -59,7 +59,12 @@
                 <button id="ga-cancel-btn" class="bg-rose-500 hover:bg-rose-600 text-white font-bold py-2 px-4 rounded disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-150 ease-in-out">Cancel</button>
             </div>
             <!-- Chart.js Canvas -->
-            <div id="ga-charts-placeholder" class="mt-4">
+            <div class="mt-4 flex items-center space-x-3">
+                <input type="checkbox" id="toggle-chart" class="h-4 w-4" checked>
+                <label for="toggle-chart" class="text-sm text-gray-700">Show Chart</label>
+                <button id="download-csv" class="bg-blue-500 hover:bg-blue-600 text-white text-sm font-semibold py-1 px-2 rounded">Download CSV</button>
+            </div>
+            <div id="ga-charts-placeholder" class="mt-2">
                 <canvas id="ga-history-chart"></canvas>
             </div>
 
@@ -174,6 +179,7 @@
         const gaCancelBtn = document.getElementById('ga-cancel-btn');
 
         let fitnessChart = null;
+        let gaHistoryData = [];
         const chartData = {
             labels: [],
             datasets: [
@@ -181,6 +187,20 @@
                     label: 'Best Fitness',
                     borderColor: 'rgb(99,102,241)',
                     backgroundColor: 'rgba(99,102,241,0.3)',
+                    data: [],
+                    tension: 0.1
+                },
+                {
+                    label: 'Average Fitness',
+                    borderColor: 'rgb(16,185,129)',
+                    backgroundColor: 'rgba(16,185,129,0.3)',
+                    data: [],
+                    tension: 0.1
+                },
+                {
+                    label: 'Min Fitness',
+                    borderColor: 'rgb(239,68,68)',
+                    backgroundColor: 'rgba(239,68,68,0.3)',
                     data: [],
                     tension: 0.1
                 }
@@ -316,8 +336,14 @@
 
                 if (currentLabelIndex === chartData.datasets[0].data.length) { // New data point
                     chartData.datasets[0].data.push(parseFloat(data.best_fitness));
+                    chartData.datasets[1].data.push(parseFloat(data.fitness_mean));
+                    chartData.datasets[2].data.push(parseFloat(data.fitness_min));
+                    gaHistoryData.push({generation: data.generation, best_fitness: data.best_fitness, fitness_mean: data.fitness_mean, fitness_min: data.fitness_min});
                 } else if (currentLabelIndex !== -1 && currentLabelIndex < chartData.datasets[0].data.length) { // Update existing data point
                     chartData.datasets[0].data[currentLabelIndex] = parseFloat(data.best_fitness);
+                    chartData.datasets[1].data[currentLabelIndex] = parseFloat(data.fitness_mean);
+                    chartData.datasets[2].data[currentLabelIndex] = parseFloat(data.fitness_min);
+                    gaHistoryData[currentLabelIndex] = {generation: data.generation, best_fitness: data.best_fitness, fitness_mean: data.fitness_mean, fitness_min: data.fitness_min};
                 }
 
 
@@ -494,8 +520,11 @@
                 const response = await fetch('/api/ga/history');
                 if (response.ok) {
                     const history = await response.json();
+                    gaHistoryData = history;
                     chartData.labels = history.map(h => h.generation);
                     chartData.datasets[0].data = history.map(h => h.best_fitness);
+                    chartData.datasets[1].data = history.map(h => h.fitness_mean);
+                    chartData.datasets[2].data = history.map(h => h.fitness_min);
                 } else {
                     console.error('Failed to fetch GA history:', response.status);
                 }
@@ -712,6 +741,35 @@
                 } catch (error) {
                     console.error('Error cancelling GA:', error);
                 }
+            });
+        }
+
+        const toggleChart = document.getElementById('toggle-chart');
+        const chartContainer = document.getElementById('ga-charts-placeholder');
+        if (toggleChart && chartContainer) {
+            toggleChart.addEventListener('change', () => {
+                chartContainer.style.display = toggleChart.checked ? 'block' : 'none';
+            });
+        }
+
+        const downloadCsvBtn = document.getElementById('download-csv');
+        if (downloadCsvBtn) {
+            downloadCsvBtn.addEventListener('click', () => {
+                const rows = [['generation','best_fitness','average_fitness','min_fitness']];
+                gaHistoryData.forEach(h => {
+                    rows.push([h.generation, h.best_fitness, h.fitness_mean, h.fitness_min]);
+                });
+                const csvContent = rows.map(r => r.join(',')).join('\n');
+                const blob = new Blob([csvContent], { type: 'text/csv' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = 'ga_metrics.csv';
+                a.style.display = 'none';
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+                URL.revokeObjectURL(url);
             });
         }
 


### PR DESCRIPTION
## Summary
- plot average and min fitness in the dashboard chart
- add chart toggle and CSV download controls
- send GA history to WebSocket clients on connect

## Testing
- `pytest -q` *(fails: fixture 'test_user_token' not found)*

------
https://chatgpt.com/codex/tasks/task_b_68563150dcf483219dc94165119e7992