### PR TITLE
Add Prometheus metrics and experiment tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,10 @@ OPENAI_API_KEY=your_openai_api_key
 ANTHROPIC_API_KEY=your_anthropic_api_key
 GOOGLE_API_KEY=your_google_api_key
 
+# Optional experiment tracking
+WANDB_API_KEY=
+MLFLOW_TRACKING_URI=
+
 # --- Genetic algorithm defaults (Preserved from existing file) ---
 DEFAULT_POPULATION_SIZE=50
 DEFAULT_MAX_GENERATIONS=100

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ The application requires certain environment variables to be set, especially for
 *   `ANTHROPIC_API_KEY`: Your API key for Anthropic services.
 *   `GOOGLE_API_KEY`: Your API key for Google AI services.
 *   `DATABASE_URL`: The connection string for your database (e.g., `postgresql://user:password@host:port/database` for PostgreSQL, or `sqlite:///./prompthelix.db` for SQLite).
+*   `WANDB_API_KEY` *(optional)*: Enables logging metrics to Weights & Biases when set.
+*   `MLFLOW_TRACKING_URI` *(optional)*: URI of your MLflow server for metric logging.
 
 **Agent Overrides:**
 
@@ -335,6 +337,15 @@ python -m prompthelix.cli test --path tests/unit/test_architect_agent.py
 
 The output will show the progress of the tests and a summary of the results.
 
+### Metrics and Experiment Tracking
+
+PromptHelix exposes Prometheus metrics at the `/metrics` route which report
+generation number, best fitness and other GA stats. Configure a Prometheus
+server to scrape this endpoint.
+
+If the optional `WANDB_API_KEY` is set, these metrics are logged to Weights &
+Biases. Setting `MLFLOW_TRACKING_URI` enables logging to an MLflow server.  Both
+integrations activate only when the environment variables are provided.
 
 To execute interactive tests, use the `--interactive` flag. Tests will be discovered under `prompthelix/tests/interactive`:
 

--- a/prompthelix/config.py
+++ b/prompthelix/config.py
@@ -51,6 +51,10 @@ class Settings:
     ANTHROPIC_API_KEY: str | None = os.getenv("ANTHROPIC_API_KEY")
     GOOGLE_API_KEY: str | None = os.getenv("GOOGLE_API_KEY") # For Gemini or other Google models
 
+    # Optional experiment tracking integrations
+    WANDB_API_KEY: str | None = os.getenv("WANDB_API_KEY")
+    MLFLOW_TRACKING_URI: str | None = os.getenv("MLFLOW_TRACKING_URI")
+
     # Caching (e.g., Redis)
     REDIS_HOST: str = os.getenv("REDIS_HOST", "localhost")
     REDIS_PORT: int = int(os.getenv("REDIS_PORT", "6379"))

--- a/prompthelix/genetics/engine.py
+++ b/prompthelix/genetics/engine.py
@@ -876,6 +876,8 @@ class PopulationManager:
         self.is_paused: bool = False  # Added
         self.should_stop: bool = False  # Added
         self.status: str = "IDLE"  # Added
+        self._wandb_run = None
+        self._mlflow_run = None
 
         if self.population_path:
             self.load_population(self.population_path)
@@ -1388,6 +1390,45 @@ class PopulationManager:
             additional_data={"generation": self.generation_number},
             selected_parent_ids=unique_parent_ids, # Pass unique parent IDs
         )  # Added
+
+        # Update Prometheus metrics and optional experiment trackers
+        from prompthelix.metrics import record_generation
+        from prompthelix.config import settings
+
+        best = self.get_fittest_individual()
+        best_fitness = best.fitness_score if best else 0.0
+        record_generation(
+            self.generation_number,
+            len(self.population),
+            best_fitness,
+            evaluated_chromosomes_count,
+        )
+
+        if settings.WANDB_API_KEY:
+            try:
+                import wandb
+                if self._wandb_run is None:
+                    wandb.login(key=settings.WANDB_API_KEY)
+                    self._wandb_run = wandb.init(project="prompthelix", reinit=True)
+                if self._wandb_run:
+                    wandb.log({
+                        "generation": self.generation_number,
+                        "best_fitness": best_fitness,
+                        "population_size": len(self.population),
+                    })
+            except Exception as exc:
+                logger.error(f"WandB logging failed: {exc}")
+
+        if settings.MLFLOW_TRACKING_URI:
+            try:
+                import mlflow
+                mlflow.set_tracking_uri(settings.MLFLOW_TRACKING_URI)
+                if self._mlflow_run is None:
+                    self._mlflow_run = mlflow.start_run(run_name="prompthelix_ga")
+                mlflow.log_metric("best_fitness", best_fitness, step=self.generation_number)
+                mlflow.log_metric("population_size", len(self.population), step=self.generation_number)
+            except Exception as exc:
+                logger.error(f"MLflow logging failed: {exc}")
 
     def get_fittest_individual(self) -> PromptChromosome | None:
         """

--- a/prompthelix/main.py
+++ b/prompthelix/main.py
@@ -4,7 +4,7 @@ Initializes the FastAPI application and includes the root endpoint.
 """
 import traceback
 from fastapi import Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 # from fastapi.templating import Jinja2Templates # Moved to templating.py
 from fastapi.staticfiles import StaticFiles
@@ -14,6 +14,7 @@ from prompthelix.ui_routes import router as ui_router # Import the UI router
 # from prompthelix.websocket_manager import ConnectionManager # No longer imported directly for instantiation
 from prompthelix.globals import websocket_manager # Import the global instance
 from prompthelix.database import init_db
+from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
 
 # Call init_db to create database tables on startup
 # For production, you'd likely use Alembic migrations separately.
@@ -102,6 +103,12 @@ async def websocket_dashboard_endpoint(websocket: WebSocket):
         # For now, we'll rely on the client or server to eventually clean up the connection.
         # Consider await websocket.close(code=1011) if appropriate for specific errors.
         await websocket_manager.broadcast_json({"message": f"A client connection had an error: {type(e).__name__}"})
+
+
+@app.get("/metrics")
+async def metrics_endpoint():
+    """Expose Prometheus metrics."""
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
 
 @app.get("/")

--- a/prompthelix/metrics.py
+++ b/prompthelix/metrics.py
@@ -1,0 +1,18 @@
+from prometheus_client import Gauge, Counter
+
+# GA metrics
+
+ga_current_generation = Gauge("ga_current_generation", "Current GA generation")
+
+ga_best_fitness = Gauge("ga_best_fitness", "Best fitness score this generation")
+
+ga_population_size = Gauge("ga_population_size", "Population size after generation")
+
+ga_evaluations_total = Counter("ga_evaluations_total", "Total chromosome evaluations")
+
+def record_generation(generation: int, population_size: int, best_fitness: float, evaluated_count: int):
+    """Update Prometheus metrics for a GA generation."""
+    ga_current_generation.set(generation)
+    ga_population_size.set(population_size)
+    ga_best_fitness.set(best_fitness)
+    ga_evaluations_total.inc(evaluated_count)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,6 @@ passlib==1.7.4
 textstat>=0.7.7
 setuptools>=80
 bcrypt
+prometheus_client
+wandb
+mlflow


### PR DESCRIPTION
## Summary
- add Prometheus metrics module
- expose /metrics endpoint
- update GA engine to update metrics and log to W&B/MLflow
- include WANDB_API_KEY and MLFLOW_TRACKING_URI in config and `.env.example`
- document metrics and experiment tracking in README
- update requirements

## Testing
- `pip install -r requirements.txt -q`
- `pytest -q` *(fails: 114 failed, 378 passed, 7 skipped, 1 error)*

------
https://chatgpt.com/codex/tasks/task_b_6856315269b483219276df720d1b2c16