### PR TITLE
Add GA fitness_mean and fitness_min metrics to dashboard

### DIFF
--- a/prompthelix/templates/dashboard.html
+++ b/prompthelix/templates/dashboard.html
@@ -183,6 +183,20 @@
                     backgroundColor: 'rgba(99,102,241,0.3)',
                     data: [],
                     tension: 0.1
+                },
+                {
+                    label: 'Average Fitness',
+                    borderColor: 'rgb(16,185,129)',
+                    backgroundColor: 'rgba(16,185,129,0.3)',
+                    data: [],
+                    tension: 0.1
+                },
+                {
+                    label: 'Min Fitness',
+                    borderColor: 'rgb(234,88,12)',
+                    backgroundColor: 'rgba(234,88,12,0.3)',
+                    data: [],
+                    tension: 0.1
                 }
             ]
         };
@@ -316,8 +330,12 @@
 
                 if (currentLabelIndex === chartData.datasets[0].data.length) { // New data point
                     chartData.datasets[0].data.push(parseFloat(data.best_fitness));
+                    chartData.datasets[1].data.push(parseFloat(data.fitness_mean));
+                    chartData.datasets[2].data.push(parseFloat(data.fitness_min));
                 } else if (currentLabelIndex !== -1 && currentLabelIndex < chartData.datasets[0].data.length) { // Update existing data point
                     chartData.datasets[0].data[currentLabelIndex] = parseFloat(data.best_fitness);
+                    chartData.datasets[1].data[currentLabelIndex] = parseFloat(data.fitness_mean);
+                    chartData.datasets[2].data[currentLabelIndex] = parseFloat(data.fitness_min);
                 }
 
 
@@ -496,6 +514,8 @@
                     const history = await response.json();
                     chartData.labels = history.map(h => h.generation);
                     chartData.datasets[0].data = history.map(h => h.best_fitness);
+                    chartData.datasets[1].data = history.map(h => h.fitness_mean);
+                    chartData.datasets[2].data = history.map(h => h.fitness_min);
                 } else {
                     console.error('Failed to fetch GA history:', response.status);
                 }


### PR DESCRIPTION
## Summary
- show Average and Min fitness lines on dashboard chart
- keep historical fitness_mean and fitness_min data in GA engine history

## Testing
- `pytest -q` *(fails: Expected 'broadcast_ga_update' to be called once ...)*

------
https://chatgpt.com/codex/tasks/task_b_6856316e60ac832188663da5f52a1a75