### PR TITLE
Add Prometheus metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ AI prompts through innovative techniques inspired by genetic algorithms and mult
         *   Real-time metrics and logs streamed via WebSockets.
         *   Line chart visualizing max, mean, and min fitness across generations.
         *   Agent metrics and conversation events are displayed to show how interactions influence GA evolution.
+*   Prometheus metrics exported at `/metrics` for monitoring
 *   Performance tracking and evaluation of prompts
 *   API for programmatic access and integration
 *   User interface for managing and experimenting with prompts (basic HTML interface available)
@@ -58,6 +59,7 @@ The application requires certain environment variables to be set, especially for
 *   `ANTHROPIC_API_KEY`: Your API key for Anthropic services.
 *   `GOOGLE_API_KEY`: Your API key for Google AI services.
 *   `DATABASE_URL`: The connection string for your database (e.g., `postgresql://user:password@host:port/database` for PostgreSQL, or `sqlite:///./prompthelix.db` for SQLite).
+*   `WANDB_API_KEY`: Optional key for logging metrics to Weights & Biases.
 
 **Agent Overrides:**
 
@@ -316,6 +318,11 @@ PromptHelix also provides an API endpoint to trigger the genetic algorithm.
     }
     ```
     Note: The actual prompt and fitness score will vary with each run due to the nature of the genetic algorithm.
+
+## Metrics and Monitoring
+
+The application exposes Prometheus metrics at `/metrics`. When the optional `wandb` package is installed and `WANDB_API_KEY` is set, these metrics are also logged to Weights & Biases.
+
 
 ### Running Tests
 

--- a/prompthelix/genetics/engine.py
+++ b/prompthelix/genetics/engine.py
@@ -5,7 +5,7 @@ import copy
 import json
 import os
 import random
-import statistics # Added import
+import statistics  # Added import
 
 from typing import TYPE_CHECKING, Optional, Dict  # Ensure Optional is here
 import asyncio  # Added
@@ -16,6 +16,7 @@ from prompthelix.config import (
 )  # Renamed to avoid conflict
 from prompthelix import config as global_ph_config  # For LLM_UTILS_SETTINGS
 import logging
+from prompthelix.metrics import update_ga_metrics
 from prompthelix.enums import ExecutionMode  # Added import
 
 # from typing import Optional, Dict # Already imported above and updated
@@ -845,6 +846,7 @@ class PopulationManager:
         # Allow duck-typed objects in tests by skipping strict isinstance checks
         # Tests often pass MagicMock instances for these dependencies
         from prompthelix.agents.architect import PromptArchitectAgent
+
         if population_size <= 0:
             raise ValueError("Population size must be positive.")
         if elitism_count < 0 or elitism_count > population_size:
@@ -907,7 +909,7 @@ class PopulationManager:
         self,
         event_type: str = "ga_status_update",
         additional_data: Optional[dict] = None,
-        selected_parent_ids: Optional[list[str]] = None, # Added
+        selected_parent_ids: Optional[list[str]] = None,  # Added
     ):  # Added
         if not self.message_bus or not self.message_bus.connection_manager:
             # logger.debug("Message bus or connection manager not available for GA update broadcast.")
@@ -916,32 +918,42 @@ class PopulationManager:
         fittest = self.get_fittest_individual()
         fitness_scores = []
         if self.population:
-            fitness_scores = [c.fitness_score for c in self.population if hasattr(c, 'fitness_score')]
+            fitness_scores = [
+                c.fitness_score for c in self.population if hasattr(c, "fitness_score")
+            ]
 
         # --- Begin added logic for population sample ---
         population_sample_data = []
         if self.population:
             # Ensure population is sorted by fitness (descending)
             # get_fittest_individual might have already sorted it, but to be sure:
-            sorted_population_for_sample = sorted(self.population, key=lambda chromo: chromo.fitness_score, reverse=True)
+            sorted_population_for_sample = sorted(
+                self.population, key=lambda chromo: chromo.fitness_score, reverse=True
+            )
 
-            sample_size = min(len(sorted_population_for_sample), 5) # Take top 5 or fewer
+            sample_size = min(
+                len(sorted_population_for_sample), 5
+            )  # Take top 5 or fewer
             for chromo in sorted_population_for_sample[:sample_size]:
                 processed_genes = []
                 for gene in chromo.genes:
                     gene_str = str(gene)
-                    if len(gene_str) > 50: # Truncate long gene strings
+                    if len(gene_str) > 50:  # Truncate long gene strings
                         gene_str = gene_str[:47] + "..."
                     processed_genes.append(gene_str)
 
-                if len(processed_genes) > 3: # Limit number of genes shown per chromosome
+                if (
+                    len(processed_genes) > 3
+                ):  # Limit number of genes shown per chromosome
                     processed_genes = processed_genes[:3] + ["... (more genes)"]
 
-                population_sample_data.append({
-                    "id": str(chromo.id), # Ensure UUID is string
-                    "genes": processed_genes, # List of strings
-                    "fitness_score": chromo.fitness_score # Float
-                })
+                population_sample_data.append(
+                    {
+                        "id": str(chromo.id),  # Ensure UUID is string
+                        "genes": processed_genes,  # List of strings
+                        "fitness_score": chromo.fitness_score,  # Float
+                    }
+                )
         # --- End added logic for population sample ---
 
         payload = {
@@ -959,10 +971,18 @@ class PopulationManager:
             "fitness_min": min(fitness_scores) if fitness_scores else None,
             "fitness_max": max(fitness_scores) if fitness_scores else None,
             "fitness_mean": statistics.mean(fitness_scores) if fitness_scores else None,
-            "fitness_median": statistics.median(fitness_scores) if fitness_scores else None,
-            "fitness_std_dev": statistics.stdev(fitness_scores) if len(fitness_scores) > 1 else (0.0 if fitness_scores else None),
-            "population_sample": population_sample_data, # Add the new sample data to the payload
-            "selected_parent_ids": selected_parent_ids if selected_parent_ids is not None else [], # Added
+            "fitness_median": (
+                statistics.median(fitness_scores) if fitness_scores else None
+            ),
+            "fitness_std_dev": (
+                statistics.stdev(fitness_scores)
+                if len(fitness_scores) > 1
+                else (0.0 if fitness_scores else None)
+            ),
+            "population_sample": population_sample_data,  # Add the new sample data to the payload
+            "selected_parent_ids": (
+                selected_parent_ids if selected_parent_ids is not None else []
+            ),  # Added
         }
         if additional_data:
             payload.update(additional_data)
@@ -970,12 +990,18 @@ class PopulationManager:
         # Store history for API retrieval
         try:
             from prompthelix import globals as ph_globals
-            ph_globals.ga_history.append({
-                "generation": self.generation_number,
-                "best_fitness": payload.get("best_fitness")
-            })
+
+            ph_globals.ga_history.append(
+                {
+                    "generation": self.generation_number,
+                    "best_fitness": payload.get("best_fitness"),
+                }
+            )
         except Exception:
             pass
+
+        # Update Prometheus gauges and optionally log to Weights & Biases
+        update_ga_metrics(self.generation_number, payload.get("best_fitness"))
 
         try:
             loop = asyncio.get_running_loop()
@@ -1109,8 +1135,8 @@ class PopulationManager:
         task_description: str,
         success_criteria: dict | None = None,
         target_style: str | None = None,
-        db_session: 'DbSession' | None = None,
-        experiment_run: 'GAExperimentRun' | None = None,
+        db_session: "DbSession" | None = None,
+        experiment_run: "GAExperimentRun" | None = None,
     ):
         """
         Orchestrates one generation of evolution: evaluation, selection, crossover, and mutation.
@@ -1122,6 +1148,7 @@ class PopulationManager:
                 StyleOptimizerAgent is available. Defaults to None.
         """
         from prompthelix.services import add_chromosome_record
+
         if self.should_stop:  # Moved this check up, and modified its behavior
             logger.info(
                 f"PopulationManager.evolve_population: Stop requested before starting generation {self.generation_number + 1}. Aborting evolution for this generation."
@@ -1140,7 +1167,7 @@ class PopulationManager:
         self.broadcast_ga_update(
             event_type="ga_generation_started",
             additional_data={"generation": self.generation_number + 1},
-            selected_parent_ids=None, # Explicitly None
+            selected_parent_ids=None,  # Explicitly None
         )  # Added
 
         if not self.population:
@@ -1251,16 +1278,19 @@ class PopulationManager:
         )
         # failed_evaluations_count is correct
 
-
         # Log fitness statistics before sorting
-        if self.population: # Ensure population is not empty
-            fitness_scores = [c.fitness_score for c in self.population if hasattr(c, 'fitness_score')] # Added check for attribute
-            if fitness_scores: # Ensure we have scores to process
+        if self.population:  # Ensure population is not empty
+            fitness_scores = [
+                c.fitness_score for c in self.population if hasattr(c, "fitness_score")
+            ]  # Added check for attribute
+            if fitness_scores:  # Ensure we have scores to process
                 min_fitness = min(fitness_scores)
                 max_fitness = max(fitness_scores)
                 mean_fitness = statistics.mean(fitness_scores)
                 median_fitness = statistics.median(fitness_scores)
-                std_dev_fitness = statistics.stdev(fitness_scores) if len(fitness_scores) > 1 else 0.0
+                std_dev_fitness = (
+                    statistics.stdev(fitness_scores) if len(fitness_scores) > 1 else 0.0
+                )
 
                 logger.info(
                     f"Generation {current_generation_number}: Fitness Stats - "
@@ -1270,10 +1300,13 @@ class PopulationManager:
                     f"StdDev: {std_dev_fitness:.4f}"
                 )
             else:
-                logger.info(f"Generation {current_generation_number}: No valid fitness scores found in population to report statistics.")
+                logger.info(
+                    f"Generation {current_generation_number}: No valid fitness scores found in population to report statistics."
+                )
         else:
-            logger.info(f"Generation {current_generation_number}: Population is empty, no fitness statistics to report.")
-
+            logger.info(
+                f"Generation {current_generation_number}: Population is empty, no fitness statistics to report."
+            )
 
         logger.info(
             f"PopulationManager: Fitness evaluation complete for generation {current_generation_number}."
@@ -1293,7 +1326,7 @@ class PopulationManager:
                 "evaluated_count": successful_evaluations,
                 "failed_count": failed_evaluations_count,
             },
-            selected_parent_ids=None, # Explicitly None
+            selected_parent_ids=None,  # Explicitly None
         )  # Added
 
         # 2. Sort Population by fitness (descending)
@@ -1332,16 +1365,22 @@ class PopulationManager:
         num_offspring_needed = self.population_size - len(new_population)
 
         generated_offspring_count = 0
-        current_generation_selected_parent_ids = [] # Initialize list to store parent IDs
+        current_generation_selected_parent_ids = (
+            []
+        )  # Initialize list to store parent IDs
 
         # Ensure there's a viable population to select from for breeding
         if sorted_population:  # Check if sorted_population is not empty
             while generated_offspring_count < num_offspring_needed:
                 # Selection - logging is inside genetic_operators.selection
                 parent1 = self.genetic_operators.selection(sorted_population)
-                current_generation_selected_parent_ids.append(str(parent1.id)) # Add parent1 ID
+                current_generation_selected_parent_ids.append(
+                    str(parent1.id)
+                )  # Add parent1 ID
                 parent2 = self.genetic_operators.selection(sorted_population)
-                current_generation_selected_parent_ids.append(str(parent2.id)) # Add parent2 ID
+                current_generation_selected_parent_ids.append(
+                    str(parent2.id)
+                )  # Add parent2 ID
 
                 # Crossover - logging is inside genetic_operators.crossover
                 child1, child2 = self.genetic_operators.crossover(parent1, parent2)
@@ -1381,12 +1420,14 @@ class PopulationManager:
         logger.info(
             f"PopulationManager: Evolution complete for generation {self.generation_number}. New population size: {len(self.population)}. Status: {self.status}"
         )
-        unique_parent_ids = list(set(current_generation_selected_parent_ids)) # Get unique parent IDs
+        unique_parent_ids = list(
+            set(current_generation_selected_parent_ids)
+        )  # Get unique parent IDs
 
         self.broadcast_ga_update(
             event_type="ga_generation_complete",
             additional_data={"generation": self.generation_number},
-            selected_parent_ids=unique_parent_ids, # Pass unique parent IDs
+            selected_parent_ids=unique_parent_ids,  # Pass unique parent IDs
         )  # Added
 
     def get_fittest_individual(self) -> PromptChromosome | None:

--- a/prompthelix/main.py
+++ b/prompthelix/main.py
@@ -2,24 +2,28 @@
 Main application file for the PromptHelix API.
 Initializes the FastAPI application and includes the root endpoint.
 """
+
 import traceback
 from fastapi import Request
 from fastapi.responses import JSONResponse
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+
 # from fastapi.templating import Jinja2Templates # Moved to templating.py
 from fastapi.staticfiles import StaticFiles
-from prompthelix.templating import templates # Import templates object
+from prompthelix.templating import templates  # Import templates object
 from prompthelix.api import routes as api_routes
-from prompthelix.ui_routes import router as ui_router # Import the UI router
+from prompthelix.ui_routes import router as ui_router  # Import the UI router
+from prompthelix import metrics as ph_metrics
+
 # from prompthelix.websocket_manager import ConnectionManager # No longer imported directly for instantiation
-from prompthelix.globals import websocket_manager # Import the global instance
+from prompthelix.globals import websocket_manager  # Import the global instance
 from prompthelix.database import init_db
 
 # Call init_db to create database tables on startup
 # For production, you'd likely use Alembic migrations separately.
 # init_db() # This should be commented out for tests; conftest.py handles DB setup.
-            # For running the app directly (e.g. `python -m prompthelix.main`),
-            # it might be called below if __name__ == "__main__".
+# For running the app directly (e.g. `python -m prompthelix.main`),
+# it might be called below if __name__ == "__main__".
 
 # Initialize FastAPI application
 app = FastAPI()
@@ -59,8 +63,8 @@ async def generic_exception_handler(request: Request, exc: Exception):
 
     # For now, always include traceback as per user request for easier debugging in current context.
     # Consider adding a DEBUG flag check for production.
-    print(f"Unhandled exception: {exc}") # Basic logging
-    traceback.print_exc() # Print traceback to server console
+    print(f"Unhandled exception: {exc}")  # Basic logging
+    traceback.print_exc()  # Print traceback to server console
 
     return JSONResponse(
         status_code=500,
@@ -88,11 +92,15 @@ async def websocket_dashboard_endpoint(websocket: WebSocket):
         while True:
             data = await websocket.receive_text()
             print(f"WebSocket dashboard received: {data}")
-            await websocket_manager.send_personal_json({"response": f"You wrote: {data}"}, websocket)
+            await websocket_manager.send_personal_json(
+                {"response": f"You wrote: {data}"}, websocket
+            )
     except WebSocketDisconnect:
         websocket_manager.disconnect(websocket)
         print("WebSocket dashboard disconnected")
-        await websocket_manager.broadcast_json({"message": "A client has disconnected."})
+        await websocket_manager.broadcast_json(
+            {"message": "A client has disconnected."}
+        )
     except Exception as e:
         websocket_manager.disconnect(websocket)
         print(f"WebSocket dashboard error: {e}")
@@ -101,7 +109,9 @@ async def websocket_dashboard_endpoint(websocket: WebSocket):
         # Depending on the error, the websocket might already be closed or in an unusable state.
         # For now, we'll rely on the client or server to eventually clean up the connection.
         # Consider await websocket.close(code=1011) if appropriate for specific errors.
-        await websocket_manager.broadcast_json({"message": f"A client connection had an error: {type(e).__name__}"})
+        await websocket_manager.broadcast_json(
+            {"message": f"A client connection had an error: {type(e).__name__}"}
+        )
 
 
 @app.get("/")
@@ -115,6 +125,7 @@ async def root():
 
 # Include API routes
 app.include_router(api_routes.router)
+app.include_router(ph_metrics.router)
 # Include UI routes
 app.include_router(ui_router)
 
@@ -122,11 +133,11 @@ if __name__ == "__main__":
     # This block is for when you run the application directly, e.g., using `python -m prompthelix.main`
     # It's a good place to initialize the database if it hasn't been set up by other means (like Alembic).
     # init_db() # Uncomment if you want to ensure DB is created/checked when running directly.
-                # However, be cautious if you use Alembic for migrations, as this might conflict.
-                # For development, manually running `init_db()` via a script or an initial check might be safer.
+    # However, be cautious if you use Alembic for migrations, as this might conflict.
+    # For development, manually running `init_db()` via a script or an initial check might be safer.
 
     # Note: Uvicorn is typically used to run the app, e.g., `uvicorn prompthelix.main:app --reload`
     # In that case, this __main__ block might not be executed depending on how uvicorn imports/runs the app.
     # If `init_db()` is critical on every startup when not testing, ensure it's called appropriately,
     # possibly earlier in the script if not managed by a migration tool or separate startup script.
-    pass # Placeholder if no direct run actions are needed here right now.
+    pass  # Placeholder if no direct run actions are needed here right now.

--- a/prompthelix/metrics.py
+++ b/prompthelix/metrics.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter, Response
+from prometheus_client import Gauge, generate_latest, CONTENT_TYPE_LATEST
+
+from .wandb_logger import log_metrics
+
+# Gauges for key GA metrics
+GA_GENERATION = Gauge(
+    "prompthelix_ga_generation",
+    "Current generation of the running genetic algorithm",
+)
+GA_BEST_FITNESS = Gauge(
+    "prompthelix_ga_best_fitness",
+    "Best fitness score of the current generation",
+)
+
+router = APIRouter()
+
+
+@router.get("/metrics")
+def metrics() -> Response:
+    """Expose Prometheus metrics."""
+    data = generate_latest()
+    return Response(content=data, media_type=CONTENT_TYPE_LATEST)
+
+
+def update_ga_metrics(generation: int, best_fitness: float | None) -> None:
+    """Update in-memory metrics and optionally log to Weights & Biases."""
+    GA_GENERATION.set(generation)
+    if best_fitness is not None:
+        GA_BEST_FITNESS.set(best_fitness)
+    log_metrics(
+        {
+            "prompthelix_ga_generation": generation,
+            "prompthelix_ga_best_fitness": best_fitness,
+        }
+    )

--- a/prompthelix/wandb_logger.py
+++ b/prompthelix/wandb_logger.py
@@ -1,0 +1,25 @@
+"""Minimal helper for logging metrics to Weights & Biases."""
+
+import os
+
+try:
+    import wandb  # type: ignore
+except Exception:  # Package might not be installed
+    wandb = None
+
+_run = None
+
+
+def _get_run():
+    """Initialize a W&B run if possible."""
+    global _run
+    if _run is None and wandb is not None and os.getenv("WANDB_API_KEY"):
+        _run = wandb.init(project="prompthelix", reinit=True)
+    return _run
+
+
+def log_metrics(metrics: dict) -> None:
+    """Log metrics to W&B if configured."""
+    run = _get_run()
+    if run is not None:
+        run.log(metrics)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ passlib==1.7.4
 textstat>=0.7.7
 setuptools>=80
 bcrypt
+prometheus_client==0.20.0

--- a/tests/api/test_metrics.py
+++ b/tests/api/test_metrics.py
@@ -1,0 +1,7 @@
+from fastapi.testclient import TestClient
+
+
+def test_metrics_endpoint_works(test_client: TestClient):
+    response = test_client.get("/metrics")
+    assert response.status_code == 200
+    assert "prompthelix_ga_generation" in response.text


### PR DESCRIPTION
## Summary
- expose `/metrics` endpoint exporting Prometheus metrics
- track `prompthelix_ga_generation` and `prompthelix_ga_best_fitness`
- optionally log metrics to Weights & Biases
- document metrics setup in README
- cover the new endpoint with tests

## Testing
- `pytest -q` *(fails: 114 failed, 379 passed, 7 skipped, 1 error)*

------
https://chatgpt.com/codex/tasks/task_b_68563172e70883219d3ef22484bf2a4a