### PR TITLE
Add GA generation metrics logging

### DIFF
--- a/alembic/versions/31054ccb0722_add_ga_generation_metrics.py
+++ b/alembic/versions/31054ccb0722_add_ga_generation_metrics.py
@@ -1,0 +1,36 @@
+"""add ga generation metrics
+
+Revision ID: 31054ccb0722
+Revises: 3ef25a559d5b
+Create Date: 2025-06-21 04:17:11.848640
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '31054ccb0722'
+down_revision: Union[str, None] = '3ef25a559d5b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'ga_generation_metrics',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True, nullable=False),
+        sa.Column('run_id', sa.Integer(), nullable=False),
+        sa.Column('generation_number', sa.Integer(), nullable=False),
+        sa.Column('best_fitness', sa.Float(), nullable=False),
+        sa.Column('avg_fitness', sa.Float(), nullable=False),
+        sa.Column('population_diversity', sa.Float(), nullable=False),
+        sa.Column('timestamp', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['run_id'], ['ga_experiment_runs.id']),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('ga_generation_metrics')

--- a/prompthelix/api/routes.py
+++ b/prompthelix/api/routes.py
@@ -33,6 +33,7 @@ from prompthelix.services import (
     get_experiment_runs,
     get_experiment_run,
     get_chromosomes_for_run,
+    get_generation_metrics_for_run,
 )
 from prompthelix.services.prompt_service import PromptService
 
@@ -334,9 +335,20 @@ def get_ga_experiment_status():
 
 
 # --- GA History Route ---
-@router.get("/api/ga/history", tags=["GA Control"], summary="Get GA fitness history")
-def get_ga_history():
-    return ph_globals.ga_history
+@router.get(
+    "/api/ga/history",
+    response_model=List[schemas.GAGenerationMetric],
+    tags=["GA Control"],
+    summary="Get GA fitness history",
+)
+def get_ga_history(
+    run_id: int,
+    skip: int = 0,
+    limit: int = 100,
+    db: DbSession = Depends(get_db),
+):
+    metrics = get_generation_metrics_for_run(db=db, run_id=run_id)
+    return metrics[skip : skip + limit]
 
 
 @router.get(

--- a/prompthelix/genetics/engine.py
+++ b/prompthelix/genetics/engine.py
@@ -1274,6 +1274,17 @@ class PopulationManager:
         else:
             logger.info(f"Generation {current_generation_number}: Population is empty, no fitness statistics to report.")
 
+        if db_session and experiment_run and fitness_scores:
+            from prompthelix.services import add_generation_metric
+            add_generation_metric(
+                db_session,
+                experiment_run,
+                current_generation_number,
+                max_fitness,
+                mean_fitness,
+                std_dev_fitness,
+            )
+
 
         logger.info(
             f"PopulationManager: Fitness evaluation complete for generation {current_generation_number}."

--- a/prompthelix/models/__init__.py
+++ b/prompthelix/models/__init__.py
@@ -5,7 +5,7 @@ from .statistics_models import LLMUsageStatistic # Add this import
 from .user_models import User, Session
 from .performance_models import PerformanceMetric
 from .conversation_models import ConversationLog
-from .evolution_models import GAExperimentRun, GAChromosome
+from .evolution_models import GAExperimentRun, GAChromosome, GAGenerationMetric
 
 __all__ = [
     "Base",
@@ -19,4 +19,5 @@ __all__ = [
     "ConversationLog",
     "GAExperimentRun",
     "GAChromosome",
+    "GAGenerationMetric",
 ]

--- a/prompthelix/models/evolution_models.py
+++ b/prompthelix/models/evolution_models.py
@@ -29,3 +29,17 @@ class GAChromosome(Base):
 
     run = relationship("GAExperimentRun", back_populates="chromosomes")
 
+
+class GAGenerationMetric(Base):
+    __tablename__ = "ga_generation_metrics"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    run_id = Column(Integer, ForeignKey("ga_experiment_runs.id"), nullable=False)
+    generation_number = Column(Integer, nullable=False)
+    best_fitness = Column(Float, nullable=False)
+    avg_fitness = Column(Float, nullable=False)
+    population_diversity = Column(Float, nullable=False)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+    run = relationship("GAExperimentRun")
+

--- a/prompthelix/schemas.py
+++ b/prompthelix/schemas.py
@@ -258,3 +258,23 @@ class GAChromosome(GAChromosomeBase):
 
     class Config:
         from_attributes = True
+
+
+class GAGenerationMetricBase(BaseModel):
+    run_id: int
+    generation_number: int
+    best_fitness: float
+    avg_fitness: float
+    population_diversity: float
+    timestamp: datetime
+
+
+class GAGenerationMetricCreate(GAGenerationMetricBase):
+    pass
+
+
+class GAGenerationMetric(GAGenerationMetricBase):
+    id: int
+
+    class Config:
+        from_attributes = True

--- a/prompthelix/services/__init__.py
+++ b/prompthelix/services/__init__.py
@@ -24,9 +24,11 @@ from .evolution_service import (
     create_experiment_run,
     complete_experiment_run,
     add_chromosome_record,
+    add_generation_metric,
     get_chromosomes_for_run,
     get_experiment_runs,
     get_experiment_run,
+    get_generation_metrics_for_run,
 )
 
 __all__ = [
@@ -52,7 +54,9 @@ __all__ = [
     "create_experiment_run",
     "complete_experiment_run",
     "add_chromosome_record",
+    "add_generation_metric",
     "get_chromosomes_for_run",
     "get_experiment_runs",
     "get_experiment_run",
+    "get_generation_metrics_for_run",
 ]

--- a/prompthelix/services/evolution_service.py
+++ b/prompthelix/services/evolution_service.py
@@ -2,7 +2,11 @@ from typing import List, Optional, Dict, Any
 from datetime import datetime
 from sqlalchemy.orm import Session as DbSession
 
-from prompthelix.models.evolution_models import GAExperimentRun, GAChromosome
+from prompthelix.models.evolution_models import (
+    GAExperimentRun,
+    GAChromosome,
+    GAGenerationMetric,
+)
 from prompthelix.genetics.engine import PromptChromosome
 
 
@@ -57,4 +61,34 @@ def get_experiment_runs(db: DbSession, skip: int = 0, limit: int = 100) -> List[
 def get_experiment_run(db: DbSession, run_id: int) -> Optional[GAExperimentRun]:
     """Return a single GA experiment run by ID, if it exists."""
     return db.query(GAExperimentRun).filter(GAExperimentRun.id == run_id).first()
+
+
+def add_generation_metric(
+    db: DbSession,
+    run: GAExperimentRun,
+    generation_number: int,
+    best_fitness: float,
+    avg_fitness: float,
+    population_diversity: float,
+) -> GAGenerationMetric:
+    metric = GAGenerationMetric(
+        run_id=run.id,
+        generation_number=generation_number,
+        best_fitness=best_fitness,
+        avg_fitness=avg_fitness,
+        population_diversity=population_diversity,
+    )
+    db.add(metric)
+    db.commit()
+    db.refresh(metric)
+    return metric
+
+
+def get_generation_metrics_for_run(db: DbSession, run_id: int) -> List[GAGenerationMetric]:
+    return (
+        db.query(GAGenerationMetric)
+        .filter(GAGenerationMetric.run_id == run_id)
+        .order_by(GAGenerationMetric.generation_number.asc())
+        .all()
+    )
 


### PR DESCRIPTION
## Summary
- track generation metrics in a new `ga_generation_metrics` table
- expose generation history via `/api/ga/history`
- store metrics after each generation evaluation
- create Pydantic schema and service helpers

## Testing
- `pytest -q` *(fails: ImportError: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_b_68563178af0c8321817d893505f41a3d