### PR TITLE
Add Prometheus metrics exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,3 +359,15 @@ python -m prompthelix.cli test --interactive
 ```
 
 
+
+## Metrics Exporter
+
+PromptHelix can expose basic Prometheus metrics to monitor GA progress. Set
+`PROMETHEUS_METRICS_ENABLED=true` in your environment to enable the exporter.
+By default metrics are served on port defined by `PROMETHEUS_METRICS_PORT`
+(default `8001`).
+
+Once enabled, start a GA run normally and scrape `http://localhost:8001/metrics`.
+You can add this scrape target in Prometheus and visualize values like
+`prompthelix_current_generation` and `prompthelix_best_fitness` in Grafana or
+forward them to an experiment tracker such as W&B.

--- a/prompthelix/config.py
+++ b/prompthelix/config.py
@@ -71,6 +71,10 @@ class Settings:
     DEFAULT_POPULATION_PERSISTENCE_PATH: str = os.getenv("DEFAULT_POPULATION_PERSISTENCE_PATH", os.path.join(KNOWLEDGE_DIR, "ga_population.json"))
     DEFAULT_SAVE_POPULATION_FREQUENCY: int = int(os.getenv("DEFAULT_SAVE_POPULATION_FREQUENCY", "10"))
 
+    # Prometheus metrics
+    PROMETHEUS_METRICS_ENABLED: bool = os.getenv("PROMETHEUS_METRICS_ENABLED", "false").lower() == "true"
+    PROMETHEUS_METRICS_PORT: int = int(os.getenv("PROMETHEUS_METRICS_PORT", "8001"))
+
     # Security settings
     # TODO: Uncomment and set a strong, unique SECRET_KEY for production environments.
     # SECRET_KEY: str = os.getenv("SECRET_KEY", "a_very_secret_key") # For JWT, session management etc.

--- a/prompthelix/genetics/engine.py
+++ b/prompthelix/genetics/engine.py
@@ -967,13 +967,20 @@ class PopulationManager:
         if additional_data:
             payload.update(additional_data)
 
-        # Store history for API retrieval
+        # Store history for API retrieval and update metrics
         try:
             from prompthelix import globals as ph_globals
             ph_globals.ga_history.append({
                 "generation": self.generation_number,
                 "best_fitness": payload.get("best_fitness")
             })
+        except Exception:
+            pass
+
+        try:
+            from prompthelix.utils import update_generation, update_best_fitness
+            update_generation(self.generation_number)
+            update_best_fitness(payload.get("best_fitness"))
         except Exception:
             pass
 

--- a/prompthelix/globals.py
+++ b/prompthelix/globals.py
@@ -5,6 +5,7 @@ This module should be kept lightweight and free of complex imports
 to avoid circular dependencies.
 """
 from typing import Optional
+from prometheus_client import Gauge
 # Forward reference for GeneticAlgorithmRunner to avoid circular import issues
 # as experiment_runners.ga_runner will import this file.
 if False: # TYPE_CHECKING can also be used here if preferred
@@ -20,6 +21,10 @@ active_ga_runner: Optional["GeneticAlgorithmRunner"] = None
 
 # Fitness history collected during GA runs
 ga_history: list[dict] = []
+
+# Prometheus metrics gauges (initialized lazily by metrics_exporter)
+generation_gauge: Gauge | None = None
+best_fitness_gauge: Gauge | None = None
 
 # You can add other global instances here if needed, e.g., a global MessageBus
 # from prompthelix.database import SessionLocal

--- a/prompthelix/orchestrator.py
+++ b/prompthelix/orchestrator.py
@@ -21,6 +21,7 @@ from prompthelix.genetics.engine import (
 from typing import List, Optional, Dict
 from prompthelix.enums import ExecutionMode
 from prompthelix.utils.config_utils import update_settings # Assuming a utility for deep merging configs
+from prompthelix.utils import start_exporter_if_enabled, update_generation, update_best_fitness
 from prompthelix import config as global_config # To access global default settings
 from prompthelix.config import settings # Added import
 
@@ -64,6 +65,7 @@ def main_ga_loop(
     logger.info(f"Keywords: {keywords}")
     logger.info(f"Num Generations: {num_generations}, Population Size: {population_size}, Elitism Count: {elitism_count}")
     logger.info(f"Execution Mode: {execution_mode.name}")
+    start_exporter_if_enabled()
     if initial_prompt_str:
         logger.info(f"Initial Prompt String provided: '{initial_prompt_str[:100]}...'")
     if agent_settings_override:

--- a/prompthelix/utils/__init__.py
+++ b/prompthelix/utils/__init__.py
@@ -1,5 +1,15 @@
 """Utility helper functions for PromptHelix."""
 
 from .config_utils import update_settings
+from .metrics_exporter import (
+    start_exporter_if_enabled,
+    update_generation,
+    update_best_fitness,
+)
 
-__all__ = ["update_settings"]
+__all__ = [
+    "update_settings",
+    "start_exporter_if_enabled",
+    "update_generation",
+    "update_best_fitness",
+]

--- a/prompthelix/utils/metrics_exporter.py
+++ b/prompthelix/utils/metrics_exporter.py
@@ -1,0 +1,33 @@
+"""Prometheus metrics exporter for PromptHelix."""
+
+from prometheus_client import Gauge, start_http_server
+from prompthelix import config
+from prompthelix import globals as ph_globals
+
+_started = False
+
+def start_exporter_if_enabled():
+    """Start Prometheus HTTP server if enabled in settings."""
+    global _started
+    if not config.settings.PROMETHEUS_METRICS_ENABLED or _started:
+        return
+    start_http_server(config.settings.PROMETHEUS_METRICS_PORT)
+    ph_globals.generation_gauge = Gauge(
+        "prompthelix_current_generation",
+        "Current generation number of the GA",
+    )
+    ph_globals.best_fitness_gauge = Gauge(
+        "prompthelix_best_fitness",
+        "Best fitness score in the population",
+    )
+    _started = True
+
+
+def update_generation(generation: int) -> None:
+    if ph_globals.generation_gauge is not None:
+        ph_globals.generation_gauge.set(generation)
+
+
+def update_best_fitness(fitness: float | None) -> None:
+    if ph_globals.best_fitness_gauge is not None and fitness is not None:
+        ph_globals.best_fitness_gauge.set(fitness)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ passlib==1.7.4
 textstat>=0.7.7
 setuptools>=80
 bcrypt
+prometheus_client


### PR DESCRIPTION
## Summary
- allow running an optional Prometheus exporter
- export gauges for the current GA generation and best fitness
- wire exporter start into GA orchestrator
- document metrics scraping in README

## Testing
- `pip install prometheus_client`
- `pytest -q` *(fails: 114 failed, 378 passed, 7 skipped, 148 warnings, 1 error)*

------
https://chatgpt.com/codex/tasks/task_b_6856318475648321a985912aafd363a1