### PR TITLE
Fix uvicorn startup

### DIFF
--- a/prompthelix/main.py
+++ b/prompthelix/main.py
@@ -168,7 +168,6 @@ async def metrics():
 
 # Include API routes
 app.include_router(api_routes.router)
-app.include_router(ph_metrics.router)
 # Include UI routes
 app.include_router(ui_router)
 

--- a/prompthelix/orchestrator.py
+++ b/prompthelix/orchestrator.py
@@ -44,8 +44,10 @@ logger = logging.getLogger(__name__)
 
 try:
     import wandb
-except ImportError:
-    logger.info("wandb library not found. W&B logging will be disabled.")
+except Exception as e:  # broaden exception handling to avoid startup failure
+    logger.warning(
+        "wandb failed to import. W&B logging will be disabled. Error: %s", e
+    )
     wandb = None
 
 


### PR DESCRIPTION
## Summary
- handle wandb import failure gracefully
- remove invalid router include from main

## Testing
- `pytest -q` *(fails: ImportError while importing test modules)*
- `uvicorn prompthelix.main:app --reload`

------
https://chatgpt.com/codex/tasks/task_b_6856e92e85b88321b222ecac71742756