### PR TITLE
I've addressed multiple test failures across the orchestrator, agents…

### DIFF
--- a/prompthelix/agents/results_evaluator.py
+++ b/prompthelix/agents/results_evaluator.py
@@ -41,11 +41,11 @@ class ResultsEvaluatorAgent(BaseAgent):
 
         # Core LLM and fitness settings
         global_defaults = AGENT_SETTINGS.get("ResultsEvaluatorAgent", {})
-        llm_provider_default = global_defaults.get("default_llm_provider", "openai")
-        eval_model_default = global_defaults.get("evaluation_llm_model", "gpt-3.5-turbo")
+        llm_provider_default = global_defaults.get("default_llm_provider", FALLBACK_LLM_PROVIDER) # Use module fallback
+        eval_model_default = global_defaults.get("evaluation_llm_model", FALLBACK_EVAL_MODEL) # Use module fallback
         fitness_default = global_defaults.get(
             "fitness_score_weights",
-            {"constraint_adherence": 0.5, "llm_quality_assessment": 0.5},
+            FALLBACK_FITNESS_WEIGHTS, # Use module fallback
         )
 
         self.llm_provider = self.settings.get("default_llm_provider", llm_provider_default)
@@ -156,17 +156,9 @@ class ResultsEvaluatorAgent(BaseAgent):
                 f"Agent '{self.agent_id}': Error decoding JSON from '{self.knowledge_file_path}': {e}. Using default config.",
                 exc_info=True,
             )
-            logging.error(
-                f"Agent '{self.agent_id}': Error decoding JSON from '{self.knowledge_file_path}': {e}. Using default config.",
-                exc_info=True,
-            )
             self.evaluation_metrics_config = self._get_default_metrics_config()
         except Exception as e:
             logger.error(
-                f"Agent '{self.agent_id}': Failed to load metrics config from '{self.knowledge_file_path}': {e}. Using default config.",
-                exc_info=True,
-            )
-            logging.error(
                 f"Agent '{self.agent_id}': Failed to load metrics config from '{self.knowledge_file_path}': {e}. Using default config.",
                 exc_info=True,
             )


### PR DESCRIPTION
…, and engine.

This update resolves a significant number of test failures.

Key changes include:

1.  **Orchestrator & Agent Imports:**
    *   I resolved `NameError` and `ImportError` by adding missing imports for mocked objects.
    *   I fixed `AttributeError`s on mock objects by adding missing attributes.
    *   I corrected mock call assertions for `broadcast_ga_update` in GA control tests.

2.  **Agent Persistence:**
    *   I added missing `save_knowledge` and default knowledge getters to `PromptCriticAgent`.
    *   I adjusted assertions for `MetaLearnerAgent`'s compound knowledge structure.
    *   I dynamically targeted agent-specific loggers for `logging.error` patches.

3.  **Evaluation Metrics Fallback:**
    *   I refactored `setUp` and `tearDown` to robustly handle `builtins.__import__` manipulation for testing fallback mechanisms.

4.  **Pickling Errors:**
    *   For `test_population_manager.py` (`test_evolve_population_flow`): I forced serial execution to allow mock `FitnessEvaluator` assertions, avoiding pickling of the mock.
    *   I verified that `test_engine.py` (`TestPopulationManagerParallelEvaluation`) correctly uses a `SimplePicklableEvaluator`, which should prevent pickling errors for its fitness evaluator.

5.  **MetaLearnerAgent Tests:**
    *   I corrected `knowledge_file_path` resolution by fixing the agent_id used to look up config.
    *   I ensured `KNOWLEDGE_DIR` was correctly prepended in test path assertions.
    *   I fixed `persist_on_update` flag testing by ensuring agent instantiation occurred under all relevant mocks.
    *   I changed logging tests from `assertLogs` to direct `logger.error` patching, improving reliability.
    *   **Critically, I corrected the `@patch` target for `call_llm_api`**, resolving multiple LLM call mismatch failures.
    *   I adjusted test setup for `test_generate_recommendations_indirectly_updated` to ensure conditions for statistical trend recommendations were met.
    *   All 35 tests in this file now pass.

6.  **ResultsEvaluatorAgent Tests:**
    *   I removed duplicate `logging.error` calls in the agent's `load_knowledge`.
    *   I corrected the agent's fallback logic in `__init__` for default settings.
    *   I fixed `test_process_request_constraints_met` by mocking `call_llm_api` to prevent real API errors from interfering with constraint checking assertions.
    *   I overhauled logging tests by removing global `logging.disable()` and changing `assertLogs` to direct logger method patching.
    *   All 19 tests in this file now pass.

Overall, these changes have fixed a large number of issues primarily related to test setup, mock configurations (especially patch targets and logger interactions), and path handling in persistence tests.