### PR TITLE
Fix absolute paths for Jinja templates and static files

### DIFF
--- a/prompthelix/main.py
+++ b/prompthelix/main.py
@@ -4,6 +4,7 @@ Initializes the FastAPI application and includes the root endpoint.
 """
 
 import traceback
+from pathlib import Path
 from fastapi import Request
 from fastapi.responses import JSONResponse, Response
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
@@ -53,7 +54,10 @@ app = FastAPI()
 
 # Mount static files
 # templates object is now imported, no need to initialize here
-app.mount("/static", StaticFiles(directory="prompthelix/static"), name="static")
+# Mount static files using an absolute path so the server can be started from
+# any working directory.
+STATIC_DIR = Path(__file__).resolve().parent / "static"
+app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 
 
 # Add this before including routers

--- a/prompthelix/templating.py
+++ b/prompthelix/templating.py
@@ -1,3 +1,12 @@
+"""Utility for loading Jinja2 templates used by the UI."""
+
+from pathlib import Path
 from fastapi.templating import Jinja2Templates
 
-templates = Jinja2Templates(directory="prompthelix/templates")
+
+# Compute the absolute path to the "templates" directory relative to this file
+TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
+
+# Initialize the Jinja2Templates instance with the absolute directory path so
+# it works regardless of the current working directory.
+templates = Jinja2Templates(directory=str(TEMPLATE_DIR))


### PR DESCRIPTION
## Summary
- construct template path using `Path(__file__).resolve()` in templating helper
- mount static files using an absolute path

## Testing
- `pytest -q` *(fails: Unknown mark asyncio and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6856f07cea588321b2a82ac50bd38a0c