### PR TITLE
Fix WebSocketLogHandler fallback

### DIFF
--- a/prompthelix/tests/unit/test_logging_handlers.py
+++ b/prompthelix/tests/unit/test_logging_handlers.py
@@ -156,6 +156,17 @@ class TestWebSocketLogHandler(unittest.TestCase):
             # Restore the original broadcast_json mock AFTER all tests are done
             self.mock_connection_manager.broadcast_json = original_broadcast_json
 
+    @patch('asyncio.create_task')
+    def test_emit_create_task_runtime_error_falls_back_to_run(self, mock_create_task):
+        # Simulate create_task raising RuntimeError
+        mock_create_task.side_effect = RuntimeError("no event loop")
+
+        self.logger.info("runtime error test")
+
+        mock_create_task.assert_called_once()
+        # broadcast_json should still be awaited via asyncio.run
+        self.mock_connection_manager.broadcast_json.assert_awaited_once()
+
 
     def test_handler_level_respects_logger_level(self):
         # This test is more about logging configuration than the handler itself.


### PR DESCRIPTION
## Summary
- run async log broadcast synchronously if `asyncio.create_task` raises `RuntimeError`
- add unit test for the fallback

## Testing
- `pytest prompthelix/tests/unit/test_logging_handlers.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'MutationStrategy')*

------
https://chatgpt.com/codex/tasks/task_b_68570ff8bce4832195f0b60f3b5e6433