### PR TITLE
Adjust critic defaults and persistence tests

### DIFF
--- a/prompthelix/agents/critic.py
+++ b/prompthelix/agents/critic.py
@@ -32,16 +32,12 @@ class PromptCriticAgent(BaseAgent):
         self.load_knowledge()
 
     def _get_default_critique_rules(self):
-        """Returns the default critique rules."""
-        # Provide a simple default rule to satisfy tests expecting non-empty defaults.
-        return [
-            {
-                "name": "Default Placeholder Rule",
-                "pattern": ".*", # Matches anything, effectively a no-op for critique
-                "feedback": "This is a default placeholder critique rule. Consider defining specific rules.",
-                "penalty": 0
-            }
-        ]
+        """Return default critique rules.
+
+        The critic agent should not impose any rules when no knowledge file is
+        present, so the default is simply an empty list.
+        """
+        return []
 
     def load_knowledge(self):
         """


### PR DESCRIPTION
## Summary
- return an empty list from `_get_default_critique_rules`
- keep critic rules empty when no knowledge file exists
- update persistence tests for critic agent

## Testing
- `pytest prompthelix/tests/unit/test_agent_persistence.py::TestAgentPersistence::test_pca_default_load prompthelix/tests/unit/test_agent_persistence.py::TestAgentPersistence::test_pca_save_reload_modified prompthelix/tests/unit/test_agent_persistence.py::TestAgentPersistence::test_pca_corrupted_fallback tests/unit/test_critic_agent.py::TestPromptCriticAgentCustomFile::test_initialization_with_custom_file -q`

------
https://chatgpt.com/codex/tasks/task_b_685711fc0ad8832183b56a94a997f78b