### PR TITLE
Fix: Correct UI routing and ensure DB initialization

### DIFF
--- a/prompthelix/database.py
+++ b/prompthelix/database.py
@@ -6,6 +6,8 @@ from prompthelix.config import settings
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from prompthelix.models.base import Base
+# Import all models to ensure they are registered with Base.metadata
+from prompthelix import models  # This imports prompthelix/models/__init__.py
 
 DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///./prompthelix.db")
 

--- a/prompthelix/main.py
+++ b/prompthelix/main.py
@@ -44,7 +44,7 @@ configure_logging(settings.DEBUG)
 
 # Call init_db to create database tables on startup
 # For production, you'd likely use Alembic migrations separately.
-# init_db() # This should be commented out for tests; conftest.py handles DB setup.
+init_db() # Initialize database and tables on startup
 # For running the app directly (e.g. `python -m prompthelix.main`),
 # it might be called below if __name__ == "__main__".
 
@@ -173,7 +173,9 @@ async def metrics():
 # Include API routes
 app.include_router(api_routes.router)
 # Include UI routes
-app.include_router(ui_router)
+app.include_router(ui_router, prefix="/ui", tags=["UI"])
+
+# The /debug-routes endpoint has been removed.
 
 if __name__ == "__main__":
     # This block is for when you run the application directly, e.g., using `python -m prompthelix.main`

--- a/prompthelix/ui_routes.py
+++ b/prompthelix/ui_routes.py
@@ -125,17 +125,17 @@ def run_unittest(test_name: str) -> tuple[str, bool]:
     return stream.getvalue(), result.wasSuccessful()
 
 
-@router.get("/ui/", response_class=HTMLResponse, name="ui_index")
-@router.get("/ui/index", response_class=HTMLResponse, name="ui_index_alt") # Optional: alternative path
+@router.get("/", response_class=HTMLResponse, name="ui_index")
+@router.get("/index", response_class=HTMLResponse, name="ui_index_alt") # Optional: alternative path
 async def ui_index_page(request: Request):
     """Serves the UI index page."""
     return templates.TemplateResponse("index.html", {"request": request})
 
-@router.get("/ui/index.html", include_in_schema=False)
+@router.get("/index.html", include_in_schema=False)
 async def ui_index_page_alias(request: Request):
     return RedirectResponse(url=str(request.url_for("ui_index")))
 
-@router.get("/ui/prompts", name="list_prompts_ui")
+@router.get("/prompts", name="list_prompts_ui")
 async def list_prompts_ui(request: Request, db: Session = Depends(get_db), new_version_id: Optional[int] = Query(None)):
     db_prompts = crud.get_prompts(db)
     return templates.TemplateResponse(
@@ -143,19 +143,19 @@ async def list_prompts_ui(request: Request, db: Session = Depends(get_db), new_v
         {"request": request, "prompts": db_prompts, "new_version_id": new_version_id}
     )
 
-@router.get("/ui/prompts.html", include_in_schema=False)
+@router.get("/prompts.html", include_in_schema=False)
 async def list_prompts_ui_alias(request: Request):
     return RedirectResponse(url=str(request.url_for("list_prompts_ui")))
 
-@router.get("/ui/prompts/new", name="create_prompt_ui_form")
+@router.get("/prompts/new", name="create_prompt_ui_form")
 async def create_prompt_ui_form(request: Request):
     return templates.TemplateResponse("create_prompt.html", {"request": request})
 
-@router.get("/ui/prompts/new.html", include_in_schema=False)
+@router.get("/prompts/new.html", include_in_schema=False)
 async def create_prompt_ui_form_alias(request: Request):
     return RedirectResponse(url=str(request.url_for("create_prompt_ui_form")))
 
-@router.post("/ui/prompts/new", name="create_prompt_ui_submit")
+@router.post("/prompts/new", name="create_prompt_ui_submit")
 async def create_prompt_ui_submit(
     request: Request,
     db: Session = Depends(get_db),
@@ -177,7 +177,7 @@ async def create_prompt_ui_submit(
     return RedirectResponse(url=redirect_url, status_code=303)
 
 
-@router.get("/ui/experiments/new", name="run_experiment_ui_form")
+@router.get("/experiments/new", name="run_experiment_ui_form")
 async def run_experiment_ui_form(
     request: Request,
     db: Session = Depends(get_db),
@@ -189,11 +189,11 @@ async def run_experiment_ui_form(
         {"request": request, "available_prompts": available_prompts, "form_data": {}} # Pass empty form_data initially
     )
 
-@router.get("/ui/experiments/new.html", include_in_schema=False)
+@router.get("/experiments/new.html", include_in_schema=False)
 async def run_experiment_ui_form_alias(request: Request):
     return RedirectResponse(url=str(request.url_for("run_experiment_ui_form")))
 
-@router.post("/ui/experiments/new", name="run_experiment_ui_submit")
+@router.post("/experiments/new", name="run_experiment_ui_submit")
 async def run_experiment_ui_submit(
     request: Request,
     db: Session = Depends(get_db),
@@ -283,7 +283,7 @@ async def run_experiment_ui_submit(
     )
 
 
-@router.get("/ui/playground", name="llm_playground_ui")
+@router.get("/playground", name="llm_playground_ui")
 async def get_llm_playground_ui(request: Request, db: Session = Depends(get_db)):
     llm_providers = SUPPORTED_LLM_SERVICES # Static list for now
     db_prompts = crud.get_prompts(db, limit=1000) # Fetch available prompts
@@ -308,12 +308,12 @@ async def get_llm_playground_ui(request: Request, db: Session = Depends(get_db))
         }
     )
 
-@router.get("/ui/playground.html", include_in_schema=False)
+@router.get("/playground.html", include_in_schema=False)
 async def llm_playground_ui_alias(request: Request):
     return RedirectResponse(url=str(request.url_for("llm_playground_ui")))
 
 
-@router.get("/ui/prompts/{prompt_id}", name="view_prompt_ui") # Keep existing view_prompt_ui
+@router.get("/prompts/{prompt_id}", name="view_prompt_ui")
 async def view_prompt_ui(request: Request, prompt_id: int, db: Session = Depends(get_db), new_version_id: Optional[int] = Query(None)):
     db_prompt = crud.get_prompt(db, prompt_id=prompt_id)
     if db_prompt is None:
@@ -329,12 +329,12 @@ async def view_prompt_ui(request: Request, prompt_id: int, db: Session = Depends
         {"request": request, "prompt": db_prompt, "sorted_versions": sorted_versions, "new_version_id": new_version_id}
     )
 
-@router.get("/ui/prompts/{prompt_id}.html", include_in_schema=False)
+@router.get("/prompts/{prompt_id}.html", include_in_schema=False)
 async def view_prompt_ui_alias(request: Request, prompt_id: int):
     return RedirectResponse(url=str(request.url_for("view_prompt_ui", prompt_id=prompt_id)))
 
-@router.get("/ui/settings", name="view_settings_ui")
-@router.get("/ui/settings/", name="view_settings_ui_alt")
+@router.get("/settings", name="view_settings_ui")
+@router.get("/settings/", name="view_settings_ui_alt") # This path with trailing slash will also be prefixed
 async def view_settings_ui(
     request: Request,
     db: Session = Depends(get_db),
@@ -368,11 +368,11 @@ async def view_settings_ui(
         }
     )
 
-@router.get("/ui/settings.html", include_in_schema=False)
+@router.get("/settings.html", include_in_schema=False)
 async def view_settings_ui_alias(request: Request):
     return RedirectResponse(url=str(request.url_for("view_settings_ui")))
 
-@router.post("/ui/settings/api_keys", name="save_api_keys_settings")
+@router.post("/settings/api_keys", name="save_api_keys_settings")
 async def save_api_keys_settings(
     request: Request,
     db: Session = Depends(get_db)
@@ -433,26 +433,26 @@ async def save_api_keys_settings(
     return RedirectResponse(url=redirect_url, status_code=HTTP_303_SEE_OTHER)
 
 
-@router.get("/ui/conversations", response_class=HTMLResponse, name="ui_list_conversations")
+@router.get("/conversations", response_class=HTMLResponse, name="ui_list_conversations")
 async def ui_list_conversations(request: Request):
     """Serves the UI page for viewing conversation logs."""
     return templates.TemplateResponse("conversations.html", {"request": request})
 
-@router.get("/ui/conversations.html", include_in_schema=False)
+@router.get("/conversations.html", include_in_schema=False)
 async def ui_list_conversations_alias(request: Request):
     return RedirectResponse(url=str(request.url_for("ui_list_conversations")))
 
-@router.get("/ui/login", response_class=HTMLResponse, name="ui_login")
+@router.get("/login", response_class=HTMLResponse, name="ui_login")
 async def ui_login_form(request: Request):
     """Serves the UI page for user login."""
     return templates.TemplateResponse("login.html", {"request": request})
 
-@router.get("/ui/login.html", include_in_schema=False)
+@router.get("/login.html", include_in_schema=False)
 async def ui_login_form_alias(request: Request):
     return RedirectResponse(url=str(request.url_for("ui_login")))
 
 
-@router.post("/ui/login", name="ui_login_submit")
+@router.post("/login", name="ui_login_submit")
 async def ui_login_submit(
     request: Request,
     username: str = Form(...),
@@ -486,36 +486,37 @@ async def ui_login_submit(
     )
 
 
-@router.get("/ui/logout", name="ui_logout")
+@router.get("/logout", name="ui_logout")
 async def ui_logout(request: Request):
     """Logs out the current user and clears the auth cookie."""
     token = request.cookies.get("prompthelix_access_token")
     if token:
+        # The /auth/logout path is absolute
         async with httpx.AsyncClient(base_url=str(request.base_url)) as client:
             await client.post(
                 "/auth/logout",
                 headers={"Authorization": f"Bearer {token}"},
             )
     redirect = RedirectResponse(url=str(request.url_for("ui_login")), status_code=HTTP_303_SEE_OTHER)
-    redirect.delete_cookie("prompthelix_access_token", path="/")
+    redirect.delete_cookie("prompthelix_access_token", path="/") # Cookie path root
     return redirect
 
-@router.get("/ui/logout.html", include_in_schema=False)
+@router.get("/logout.html", include_in_schema=False)
 async def ui_logout_alias(request: Request):
     return RedirectResponse(url=str(request.url_for("ui_logout")))
 
 
-@router.get("/ui/dashboard", response_class=HTMLResponse, name="ui_dashboard")
+@router.get("/dashboard", response_class=HTMLResponse, name="ui_dashboard")
 async def get_dashboard_ui(request: Request):
     """Serves the UI page for the real-time monitoring dashboard."""
     return templates.TemplateResponse("dashboard.html", {"request": request})
 
-@router.get("/ui/dashboard.html", include_in_schema=False)
+@router.get("/dashboard.html", include_in_schema=False)
 async def get_dashboard_ui_alias(request: Request):
     return RedirectResponse(url=str(request.url_for("ui_dashboard")))
 
 
-@router.get("/ui/tests", response_class=HTMLResponse, name="ui_list_tests")
+@router.get("/tests", response_class=HTMLResponse, name="ui_list_tests")
 async def ui_list_tests(request: Request):
     tests = list_interactive_tests()
     return templates.TemplateResponse(
@@ -523,12 +524,12 @@ async def ui_list_tests(request: Request):
         {"request": request, "tests": tests, "selected_test": None, "test_output": None},
     )
 
-@router.get("/ui/tests.html", include_in_schema=False)
+@router.get("/tests.html", include_in_schema=False)
 async def ui_list_tests_alias(request: Request):
     return RedirectResponse(url=str(request.url_for("ui_list_tests")))
 
 
-@router.post("/ui/tests/run", response_class=HTMLResponse, name="ui_run_test")
+@router.post("/tests/run", response_class=HTMLResponse, name="ui_run_test")
 async def ui_run_test(request: Request, test_name: str = Form(...)):
     output, success = await asyncio.to_thread(run_unittest, test_name)
     tests = list_interactive_tests()


### PR DESCRIPTION
- UI routes are now correctly defined with relative paths in ui_routes.py and prefixed with '/ui' in main.py when the router is included.
- Database initialization (init_db) is now called on application startup in main.py.
- Ensured all models are imported in database.py before create_all is called, so all tables are created.
- Removed temporary /debug-routes diagnostic endpoint.

This resolves issues where UI routes were not found (due to environment/cache issues that masked the correct routing setup) and subsequent errors where database tables (e.g., 'api_keys') were missing.