### PR TITLE
Add admin user creation UI

### DIFF
--- a/prompthelix/templates/base.html
+++ b/prompthelix/templates/base.html
@@ -19,6 +19,7 @@
             <li><a href="{{ url_for('ui_dashboard') }}">Dashboard</a></li>
             <li><a href="{{ url_for('ui_list_tests') }}">Interactive Tests</a></li>
             <li><a href="{{ url_for('view_settings_ui') }}">Settings</a></li>
+            <li><a href="{{ url_for('admin_create_user_form') }}">Admin</a></li>
             <li><a href="{{ url_for('ui_login') }}">Login</a></li>
             <li><a href="{{ url_for('ui_logout') }}">Logout</a></li>
             <!-- Add other navigation links here -->

--- a/prompthelix/templates/create_user.html
+++ b/prompthelix/templates/create_user.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1>Create New User</h1>
+{% if message %}
+<p class="success-message">{{ message }}</p>
+{% endif %}
+{% if error %}
+<p class="error-message">{{ error }}</p>
+{% endif %}
+<form method="post" action="{{ url_for('admin_create_user_submit') }}">
+    <div>
+        <label for="username">Username:</label>
+        <input type="text" id="username" name="username" required>
+    </div>
+    <div>
+        <label for="email">Email:</label>
+        <input type="email" id="email" name="email" required>
+    </div>
+    <div>
+        <label for="password">Password:</label>
+        <input type="password" id="password" name="password" required>
+    </div>
+    <div>
+        <button type="submit">Create User</button>
+    </div>
+</form>
+{% endblock %}

--- a/prompthelix/tests/test_ui_admin.py
+++ b/prompthelix/tests/test_ui_admin.py
@@ -1,0 +1,41 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from prompthelix.tests.utils import get_auth_headers
+from prompthelix.services import user_service
+
+
+def _get_token(client: TestClient, db_session: Session) -> str:
+    headers = get_auth_headers(client, db_session)
+    return headers["Authorization"].split(" ")[1]
+
+
+def test_create_user_form_requires_login(client: TestClient):
+    response = client.get("/ui/admin/users/new")
+    assert response.status_code == 401
+
+
+def test_create_user_form_loads(client: TestClient, db_session: Session):
+    token = _get_token(client, db_session)
+    cookies = {"prompthelix_access_token": token}
+    response = client.get("/ui/admin/users/new", cookies=cookies)
+    assert response.status_code == 200
+    assert "<h1>Create New User</h1>" in response.text
+    assert "name=\"username\"" in response.text
+    assert "name=\"email\"" in response.text
+    assert "name=\"password\"" in response.text
+
+
+def test_admin_create_user_success(client: TestClient, db_session: Session):
+    token = _get_token(client, db_session)
+    cookies = {"prompthelix_access_token": token}
+    new_username = "newadmin@example.com"
+    form_data = {"username": new_username, "email": new_username, "password": "secret"}
+    response = client.post("/ui/admin/users/new", data=form_data, cookies=cookies, follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"].startswith("/ui/admin/users/new")
+    created_user = user_service.get_user_by_username(db_session, new_username)
+    assert created_user is not None
+    assert created_user.email == new_username
+


### PR DESCRIPTION
## Summary
- include admin section in navigation
- provide template for creating a user
- wire up GET/POST routes to create users
- test admin page

## Testing
- `python -m prompthelix.cli test` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_685735d9f99c8321a46a7f1994f1d134