### PR TITLE
Update run-ga endpoint docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,14 +339,20 @@ PromptHelix also provides an API endpoint to trigger the genetic algorithm.
     The Prompt Manager UI, for adding and viewing prompts, can be accessed as described in the "Setup and Run the Web UI" section.
 
 4.  **Expected Response**:
-    The API will return a JSON response containing the best prompt found by the genetic algorithm and its fitness score:
+    The endpoint now launches the experiment asynchronously. It immediately
+    returns a `GARunResponse` object with the task identifier and a URL for
+    checking progress:
+
     ```json
     {
-        "best_prompt": "some generated prompt text",
-        "fitness": 20
+      "message": "GA experiment started in background.",
+      "task_id": "<uuid>",
+      "status_endpoint": "/api/ga/status/<uuid>"
     }
     ```
-    Note: The actual prompt and fitness score will vary with each run due to the nature of the genetic algorithm.
+
+    The generation results can be monitored via the `status_endpoint` or by
+    visiting the GA dashboard at `/ui/dashboard`.
 
 ## Metrics and Monitoring
 


### PR DESCRIPTION
## Summary
- refresh `/api/experiments/run-ga` section of README with new `GARunResponse`
- mention async execution and monitoring via status endpoint or dashboard

## Testing
- `python -m prompthelix.cli test` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_68574ce9cb408321879939baf238424b