### PR TITLE
Fix: Await async call to llm_utils.call_llm_api

### DIFF
--- a/prompthelix/api/routes.py
+++ b/prompthelix/api/routes.py
@@ -478,7 +478,7 @@ def list_chromosomes_for_run(
 async def test_llm_prompt_route(request_data: schemas.LLMTestRequest, db: DbSession = Depends(get_db)):
 
     try:
-        response_text = llm_utils.call_llm_api(
+        response_text = await llm_utils.call_llm_api(
             prompt=request_data.prompt_text, provider=request_data.llm_service, db=db
         )
         try:


### PR DESCRIPTION
The `test_llm_prompt_route` was calling `llm_utils.call_llm_api` without `await`. Since `call_llm_api` is an asynchronous function, this resulted in a coroutine object being passed to the `LLMTestResponse` Pydantic model instead of the expected string response, causing a 400 Bad Request with a validation error.

This commit adds the necessary `await` keyword to correctly call the asynchronous function and retrieve its string result.