### PR TITLE
Fix: Resolve ImportError and subsequent SyntaxError

### DIFF
--- a/prompthelix/agents/architect.py
+++ b/prompthelix/agents/architect.py
@@ -1,6 +1,6 @@
 from prompthelix.agents.base import BaseAgent
 from prompthelix.genetics.chromosome import PromptChromosome # Updated import
-from prompthelix.utils.llm_utils import call_llm_api, DEFAULT_FALLBACK_PROVIDER, DEFAULT_FALLBACK_MODEL # Removed LLMProvider
+from prompthelix.utils.llm_utils import call_llm_api # Removed LLMProvider
 from prompthelix.config import AGENT_SETTINGS, KNOWLEDGE_DIR # Keep KNOWLEDGE_DIR for default path construction
 import os
 import json

--- a/prompthelix/agents/meta_learner.py
+++ b/prompthelix/agents/meta_learner.py
@@ -562,5 +562,3 @@ If no clear patterns emerge, return an empty list.
         recommendations = self._generate_recommendations()
         
         return {"status": "Data processed successfully.", "recommendations": recommendations}
-
-[end of prompthelix/agents/meta_learner.py]


### PR DESCRIPTION
- Removed unused imports `DEFAULT_FALLBACK_PROVIDER` and `DEFAULT_FALLBACK_MODEL` from `prompthelix.agents.architect` to fix an `ImportError`.
- Installed dependencies from `requirements.txt` to resolve a `ModuleNotFoundError` for `fastapi`.
- Corrected a `SyntaxError` in `prompthelix.agents.meta_learner` by removing extraneous lines at the end of the file.