### PR TITLE
Fix service exports

### DIFF
--- a/prompthelix/services/__init__.py
+++ b/prompthelix/services/__init__.py
@@ -24,11 +24,8 @@ from .evolution_service import (
     create_experiment_run,
     complete_experiment_run,
     add_chromosome_record,
-
     add_generation_metric,
-
-   # add_generation_metrics,
-
+    add_generation_metrics,
     get_chromosomes_for_run,
     get_experiment_runs,
     get_experiment_run,
@@ -60,6 +57,7 @@ __all__ = [
     "add_chromosome_record",
 
     "add_generation_metric",
+    "add_generation_metrics",
     "get_chromosomes_for_run",
     "get_experiment_runs",
     "get_experiment_run",


### PR DESCRIPTION
## Summary
- export `add_generation_metrics` from the `services` package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_68575d3fd1608321b16004210924a190