### PR TITLE
Convert GA code to synchronous execution

### DIFF
--- a/prompthelix/experiment_runners/ga_runner.py
+++ b/prompthelix/experiment_runners/ga_runner.py
@@ -71,7 +71,7 @@ class GeneticAlgorithmRunner(BaseExperimentRunner):
         ph_globals.active_ga_runner = self
         logger.info(f"GeneticAlgorithmRunner instance {id(self)} registered as active_ga_runner.")
 
-    async def run(self, **kwargs) -> Optional[PromptChromosome]:
+    def run(self, **kwargs) -> Optional[PromptChromosome]:
         """
         Executes the genetic algorithm for the specified number of generations.
 
@@ -133,7 +133,7 @@ class GeneticAlgorithmRunner(BaseExperimentRunner):
                     break
 
                 # evolve_population itself checks for pause/stop and updates status
-                await self.population_manager.evolve_population( # Added await
+                self.population_manager.evolve_population(
                     task_description=task_description,
                     success_criteria=success_criteria,
                     # target_style=target_style, # target_style is not used by current evolve_population

--- a/prompthelix/services/__init__.py
+++ b/prompthelix/services/__init__.py
@@ -26,8 +26,7 @@ from .evolution_service import (
     add_chromosome_record,
 
     add_generation_metric,
-
-   # add_generation_metrics,
+    add_generation_metrics,
 
     get_chromosomes_for_run,
     get_experiment_runs,
@@ -60,6 +59,7 @@ __all__ = [
     "add_chromosome_record",
 
     "add_generation_metric",
+    "add_generation_metrics",
     "get_chromosomes_for_run",
     "get_experiment_runs",
     "get_experiment_run",

--- a/prompthelix/services/evolution_service.py
+++ b/prompthelix/services/evolution_service.py
@@ -55,6 +55,7 @@ def add_generation_metrics(
         generation_number=metrics.get("generation_number"),
         best_fitness=metrics.get("best_fitness"),
         avg_fitness=metrics.get("avg_fitness"),
+        population_diversity=metrics.get("population_diversity", 0.0),
         population_size=metrics.get("population_size"),
         diversity=metrics.get("diversity"),
 

--- a/prompthelix/utils/llm_utils.py
+++ b/prompthelix/utils/llm_utils.py
@@ -17,7 +17,6 @@ from openai import (
     RateLimitError as OpenAIRateLimitError,
     AuthenticationError as OpenAIAuthenticationError,
     APIConnectionError as OpenAIAPIConnectionError,
-    AsyncOpenAI, # Added AsyncOpenAI
 )
 try:  # pragma: no cover – support both old and new OpenAI SDKs
     from openai import InvalidRequestError as OpenAIInvalidRequestError
@@ -28,7 +27,6 @@ except ImportError:  # pragma: no cover
 import anthropic
 # Renamed Anthropic client import to avoid conflict with the error type
 from anthropic import AnthropicError, APIError as AnthropicAPIError, RateLimitError as AnthropicRateLimitError, AuthenticationError as AnthropicAuthenticationError, APIStatusError as AnthropicAPIStatusError, APIConnectionError as AnthropicAPIConnectionError
-from anthropic import AsyncAnthropic as AsyncAnthropicClient # Added AsyncAnthropicClient
 
 import google.generativeai as genai
 from google.api_core import exceptions as google_exceptions
@@ -55,24 +53,24 @@ def list_available_llms(db: Session | None = None) -> list[str]:
             services.append("GOOGLE")
     return services
 
-async def call_openai_api(prompt: str, model: str = "gpt-3.5-turbo", db: Session = None) -> str: # Changed to async def
+def call_openai_api(prompt: str, model: str = "gpt-3.5-turbo", db: Session = None) -> str:
     api_key = get_openai_api_key(db)
 
     if not api_key:
         logger.warning("OpenAI API key not configured.")
         return "API_KEY_MISSING_ERROR"
 
-    client = AsyncOpenAI(api_key=api_key) # Changed to AsyncOpenAI
-    logger.info(f"Calling AsyncOpenAI API with model {model}. Prompt snippet: {prompt[:100]}...")
+    client = openai.OpenAI(api_key=api_key)
+    logger.info(f"Calling OpenAI API with model {model}. Prompt snippet: {prompt[:100]}...")
     try:
-        response = await client.chat.completions.acreate( # Changed to acreate and added await
+        response = client.chat.completions.create(
             model=model,
             messages=[{"role": "user", "content": prompt}],
         )
         content = response.choices[0].message.content.strip()
         return content
     except OpenAIRateLimitError as e:
-        logger.error(f"AsyncOpenAI API RateLimitError: {e}")
+        logger.error(f"OpenAI API RateLimitError: {e}")
         return "RATE_LIMIT_ERROR"
     except OpenAIAuthenticationError as e:
         logger.error(f"OpenAI API AuthenticationError: {e}")
@@ -93,19 +91,19 @@ async def call_openai_api(prompt: str, model: str = "gpt-3.5-turbo", db: Session
         logger.error(f"An unexpected error occurred during OpenAI API call: {e}", exc_info=True)
         return "UNEXPECTED_OPENAI_CALL_ERROR"
 
-async def call_claude_api(prompt: str, model: str = "claude-2", db: Session = None) -> str: # Changed to async def
+def call_claude_api(prompt: str, model: str = "claude-2", db: Session = None) -> str:
     api_key = get_anthropic_api_key(db)
 
     if not api_key:
         logger.warning("Anthropic API key not configured.")
         return "API_KEY_MISSING_ERROR"
 
-    client = AsyncAnthropicClient(api_key=api_key) # Changed to AsyncAnthropicClient
-    logger.info(f"Calling AsyncAnthropic Claude API with model {model}. Prompt snippet: {prompt[:100]}...")
+    client = anthropic.Anthropic(api_key=api_key)
+    logger.info(f"Calling Anthropic Claude API with model {model}. Prompt snippet: {prompt[:100]}...")
     try:
-        response = await client.messages.acreate( # Changed to acreate and added await
+        response = client.messages.create(
             model=model,
-            max_tokens=1024, # Assuming acreate supports max_tokens directly, or it's part of model config
+            max_tokens=1024,
             messages=[{"role": "user", "content": prompt}],
         )
         if response.content and isinstance(response.content, list) and len(response.content) > 0:
@@ -139,7 +137,7 @@ async def call_claude_api(prompt: str, model: str = "claude-2", db: Session = No
         logger.error(f"An unexpected error occurred during Anthropic API call: {e}", exc_info=True)
         return "UNEXPECTED_ANTHROPIC_CALL_ERROR"
 
-async def call_google_api(prompt: str, model: str = "gemini-pro", db: Session = None) -> str: # Changed to async def
+def call_google_api(prompt: str, model: str = "gemini-pro", db: Session = None) -> str:
     api_key = get_google_api_key(db)
 
     if not api_key:
@@ -148,9 +146,9 @@ async def call_google_api(prompt: str, model: str = "gemini-pro", db: Session = 
 
     genai.configure(api_key=api_key) # This is synchronous, should be fine to call once.
     model_client = genai.GenerativeModel(model)
-    logger.info(f"Calling Async Google Generative AI with model {model}. Prompt snippet: {prompt[:100]}...")
+    logger.info(f"Calling Google Generative AI with model {model}. Prompt snippet: {prompt[:100]}...")
     try:
-        response = await model_client.generate_content_async(prompt) # Changed to generate_content_async
+        response = model_client.generate_content(prompt)
         # Check response content and prompt feedback carefully
         if not response.parts: # No parts usually means blocked or empty
             if hasattr(response, 'prompt_feedback') and response.prompt_feedback.block_reason:
@@ -203,8 +201,8 @@ async def call_google_api(prompt: str, model: str = "gemini-pro", db: Session = 
             return "GOOGLE_SDK_ERROR"
         return "UNEXPECTED_GOOGLE_CALL_ERROR"
 
-async def call_llm_api(prompt: str, provider: str, model: Optional[str] = None, db: Session = None) -> str: # Changed to async def
-    logger.info(f"Async call_llm_api invoked with provider: {provider}, model: {model}")
+def call_llm_api(prompt: str, provider: str, model: Optional[str] = None, db: Session = None) -> str:
+    logger.info(f"call_llm_api invoked with provider: {provider}, model: {model}")
     provider_lower = provider.lower()
     timestamp = datetime.datetime.now().isoformat()
 
@@ -232,15 +230,15 @@ async def call_llm_api(prompt: str, provider: str, model: Optional[str] = None, 
 
     try:
         if provider_lower == "openai":
-            result = await call_openai_api(prompt, model=determined_model, db=db) # Added await
+            result = call_openai_api(prompt, model=determined_model, db=db)
             if result in ["API_KEY_MISSING_ERROR", "RATE_LIMIT_ERROR", "AUTHENTICATION_ERROR", "API_CONNECTION_ERROR", "INVALID_REQUEST_ERROR", "API_ERROR", "OPENAI_ERROR", "UNEXPECTED_OPENAI_CALL_ERROR"]:
                 error_message_for_log = result
         elif provider_lower == "anthropic":
-            result = await call_claude_api(prompt, model=determined_model, db=db) # Added await
+            result = call_claude_api(prompt, model=determined_model, db=db)
             if result in ["API_KEY_MISSING_ERROR", "RATE_LIMIT_ERROR", "AUTHENTICATION_ERROR", "API_STATUS_ERROR", "API_CONNECTION_ERROR", "API_ERROR", "ANTHROPIC_ERROR", "UNEXPECTED_ANTHROPIC_CALL_ERROR", "MALFORMED_CLAUDE_RESPONSE_CONTENT", "EMPTY_CLAUDE_RESPONSE"]:
                 error_message_for_log = result
         elif provider_lower == "google":
-            result = await call_google_api(prompt, model=determined_model, db=db) # Added await
+            result = call_google_api(prompt, model=determined_model, db=db)
             google_error_conditions = [
                 "API_KEY_MISSING_ERROR", "RATE_LIMIT_ERROR", "AUTHENTICATION_ERROR",
                 "INVALID_ARGUMENT_ERROR", "API_SERVER_ERROR", "API_ERROR",
@@ -284,5 +282,5 @@ async def call_llm_api(prompt: str, provider: str, model: Optional[str] = None, 
 
 
 # Backwards compatibility for older tests
-async def call_llm_api_directly(prompt: str, provider: str, model: Optional[str] = None, db: Session = None) -> str: # Changed to async def
-    return await call_llm_api(prompt, provider, model, db) # Added await
+def call_llm_api_directly(prompt: str, provider: str, model: Optional[str] = None, db: Session = None) -> str:
+    return call_llm_api(prompt, provider, model, db)


### PR DESCRIPTION
## Summary
- revert LLM utility helpers and GA-related methods to synchronous versions
- update ResultsEvaluatorAgent and PopulationManager for synchronous calls
- expose `add_generation_metrics` in services
- adjust unit tests for sync behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_b_68575d400c1c8321ae0bda6a54dfb388