### PR TITLE
Adjust default fitness score weights for evaluator

### DIFF
--- a/prompthelix/agents/results_evaluator.py
+++ b/prompthelix/agents/results_evaluator.py
@@ -15,7 +15,13 @@ logger = logging.getLogger(__name__)
 # Default knowledge filename if nothing else is provided
 FALLBACK_LLM_PROVIDER = "openai"
 FALLBACK_EVAL_MODEL = "gpt-4"
-FALLBACK_FITNESS_WEIGHTS = {"constraint_adherence": 0.5, "llm_quality_assessment": 0.5}
+# Weights for calculating a prompt's overall fitness score if no
+# configuration is provided via settings or AGENT_SETTINGS.  These
+# values balance constraint adherence and LLM-assessed quality equally.
+FALLBACK_FITNESS_WEIGHTS = {
+    "constraint_adherence": 0.5,
+    "llm_quality_assessment": 0.5,
+}
 FALLBACK_KNOWLEDGE_FILE = "results_evaluator_config.json"
 
 


### PR DESCRIPTION
## Summary
- document and set fallback fitness score weights to equal values when no config is present

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_68575d435e248321855a495e44a7a0d1