### PR TITLE
Fix: Enhance error reporting for /api/llm/test_prompt

### DIFF
--- a/prompthelix/api/routes.py
+++ b/prompthelix/api/routes.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks
+from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session as DbSession # Use DbSession for type hinting
 from sqlalchemy.exc import IntegrityError
@@ -6,6 +7,7 @@ from typing import List, Optional
 from pathlib import Path
 import asyncio
 import subprocess
+import traceback # Added for formatting traceback
 from datetime import datetime, timedelta
 import secrets
 import uuid # Added for task_id generation
@@ -490,8 +492,18 @@ async def test_llm_prompt_route(request_data: schemas.LLMTestRequest, db: DbSess
     except ValueError as ve:
         raise HTTPException(status_code=400, detail=str(ve))
     except Exception as e:
+        # Log the exception with traceback to the server console
         print(f"Unexpected error in test_llm_prompt_route: {e}")
-        raise HTTPException(status_code=500, detail=f"An unexpected error occurred: {str(e)}")
+        traceback.print_exc()
+        # Return a JSONResponse with traceback
+        return JSONResponse(
+            status_code=500,
+            content={
+                "message": "An unexpected error occurred in test_llm_prompt_route.",
+                "detail": str(e),
+                "traceback": traceback.format_exc(),
+            },
+        )
 
 @router.get("/api/llm/statistics", response_model=List[schemas.LLMStatistic], name="get_llm_statistics", tags=["LLM Utilities"], summary="Get LLM usage statistics", description="Retrieves statistics on the usage of different LLM services, such as call counts.")
 async def get_llm_statistics_route(db: DbSession = Depends(get_db)):


### PR DESCRIPTION
- Ensures that unexpected errors in the /api/llm/test_prompt route return a JSONResponse with a full traceback, similar to the global exception handler.
- This will help diagnose issues like the reported "object str can't be used in 'await' expression" by providing more context.
- Verified that the synchronous `call_llm_api` is not `await`ed.