### PR TITLE
feat: Allow editing prompt versions via UI

### DIFF
--- a/prompthelix/templates/edit_prompt_version.html
+++ b/prompthelix/templates/edit_prompt_version.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1>Edit Prompt: {{ prompt.name }}</h1>
+<p>Creating a new version based on Version {{ version.version_number }} (ID: {{ version.id }})</p>
+
+<form method="post" action="{{ url_for('create_prompt_version_from_existing_ui', prompt_id=prompt.id) }}">
+    <input type="hidden" name="original_version_id" value="{{ version.id }}">
+
+    <div>
+        <label for="content">Prompt Content:</label>
+        <textarea name="content" id="content" rows="15" style="width: 100%;">{{ version.content }}</textarea>
+    </div>
+
+    <button type="submit">Save Changes as New Version</button>
+    <a href="{{ url_for('view_prompt_ui', prompt_id=prompt.id) }}" class="button-secondary">Cancel</a>
+</form>
+
+{% endblock %}

--- a/prompthelix/templates/prompt_detail.html
+++ b/prompthelix/templates/prompt_detail.html
@@ -33,6 +33,7 @@
         <p><strong>Parameters Used:</strong></p>
         <pre>{{ version.parameters_used | tojson(indent=2) }}</pre>
         {% endif %}
+        <p><a href="{{ url_for('edit_prompt_version_form_ui', prompt_id=prompt.id, version_id=version.id) }}" class="button-secondary">Edit this version</a></p>
     </li>
     <hr>
     {% endfor %}


### PR DESCRIPTION
This change introduces the ability for users to edit existing prompt versions through the web UI.

Key changes:
- Added an "Edit this version" button to each version on the prompt detail page.
- Created a new page and template (`edit_prompt_version.html`) for the editing form, pre-filled with the selected version's content.
- Implemented new UI routes in `ui_routes.py`:
    - GET /ui/prompts/{prompt_id}/versions/{version_id}/edit_form to display the edit form.
    - POST /ui/prompts/{prompt_id}/versions/create_from_existing to save the edited content as a new version of the prompt.
- The system creates a new version when changes are saved, preserving the history of previous versions.
- Includes redirection to the prompt detail page with a success message and highlighting of the new version.