### PR TITLE
fix: Set top_level_dir in unittest discovery

### DIFF
--- a/prompthelix/ui_routes.py
+++ b/prompthelix/ui_routes.py
@@ -198,7 +198,8 @@ def list_tests_for_suite(suite_id: str) -> List[str]:
         if os.path.isdir(tests_dir):
             discovered_suite = loader.discover(
                 start_dir=tests_dir,
-                pattern=suite_config.get("pattern", "test_*.py") # Use configured pattern
+                pattern=suite_config.get("pattern", "test_*.py"), # Use configured pattern
+                top_level_dir=project_root # Explicitly set top_level_dir
             )
             _collect_from_suite(discovered_suite, all_test_names)
         else:


### PR DESCRIPTION
Amends previous commit.

This change addresses an `AssertionError: Path must be within the project` that occurred during test discovery in `prompthelix/ui_routes.py`.

The `unittest.TestLoader.discover()` method now explicitly has its `top_level_dir` parameter set to the calculated `project_root`. This ensures that the loader correctly interprets all test directory paths as being part of the project, resolving potential ambiguities in module path calculation and satisfying the internal assertions of the loader.