### PR TITLE
Clean up legacy metrics and document prompt manager deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,8 +339,11 @@ PromptHelix also provides an API endpoint to trigger the genetic algorithm.
     ```
 
 
-3.  **Try the Prompt Manager UI**:
-    The Prompt Manager UI, for adding and viewing prompts, can be accessed as described in the "Setup and Run the Web UI" section.
+3.  **Try the Prompt Manager UI** *(deprecated)*:
+    The original in-memory Prompt Manager has been replaced by the
+    database-backed `PromptService`. The existing UI still works but now
+    delegates all operations to `PromptService`. See "Setup and Run the
+    Web UI" for details.
 
 4.  **Expected Response**:
     The endpoint now launches the experiment asynchronously. It immediately

--- a/prompthelix/metrics.py
+++ b/prompthelix/metrics.py
@@ -132,61 +132,10 @@ def initialize_ga_metrics():
 # If the app restarts, gauges will reset to 0 by default if not set.
 # Counters will effectively restart from 0 for the new process.
 """old
-
-from fastapi import APIRouter, Response
-from prometheus_client import Gauge, generate_latest, CONTENT_TYPE_LATEST, counter
-
-from .wandb_logger import log_metrics
-
-# Gauges for key GA metrics
-GA_GENERATION = Gauge(
-    "prompthelix_ga_generation",
-    "Current generation of the running genetic algorithm",
-)
-GA_BEST_FITNESS = Gauge(
-    "prompthelix_ga_best_fitness",
-    "Best fitness score of the current generation",
-)
-
-router = APIRouter()
-
-
-@router.get("/metrics")
-def metrics() -> Response:
-#   
-    data = generate_latest()
-    return Response(content=data, media_type=CONTENT_TYPE_LATEST)
-
-
-def update_ga_metrics(generation: int, best_fitness: float | None) -> None:
-   
-    GA_GENERATION.set(generation)
-    if best_fitness is not None:
-        GA_BEST_FITNESS.set(best_fitness)
-    log_metrics(
-        {
-            "prompthelix_ga_generation": generation,
-            "prompthelix_ga_best_fitness": best_fitness,
-        }
-    )
-
-from prometheus_client import Gauge, Counter
-
-# GA metrics
-
-ga_current_generation = Gauge("ga_current_generation", "Current GA generation")
-
-ga_best_fitness = Gauge("ga_best_fitness", "Best fitness score this generation")
-
-ga_population_size = Gauge("ga_population_size", "Population size after generation")
-
-ga_evaluations_total = Counter("ga_evaluations_total", "Total chromosome evaluations")
-
-def record_generation(generation: int, population_size: int, best_fitness: float, evaluated_count: int):
-
-    ga_current_generation.set(generation)
-    ga_population_size.set(population_size)
-    ga_best_fitness.set(best_fitness)
-    ga_evaluations_total.inc(evaluated_count)
-
+This block previously exposed a `/metrics` endpoint and helper
+functions for updating GA metrics. The implementation was replaced by
+`initialize_ga_metrics` and Prometheus gauges above and is retained
+only for reference. All former helper functions such as
+``update_ga_metrics`` and ``record_generation`` have been removed as
+they are no longer used.
 """

--- a/prompthelix/services/TODO.md
+++ b/prompthelix/services/TODO.md
@@ -2,7 +2,9 @@
 
 Items for service layer expansion.
 
-- [ ] Replace in-memory PromptManager with database-backed service
+- [x] Replace in-memory PromptManager with database-backed `PromptService`
+  (the old `PromptManager` class remains for backward compatibility but is
+  deprecated)
 - [ ] Add caching layer using Redis
 - [ ] Implement background workers for long-running tasks
 - [ ] Provide service interfaces for agent coordination


### PR DESCRIPTION
## Summary
- clarify that the Prompt Manager UI is deprecated and uses PromptService
- mark PromptManager replacement in services TODO
- trim unused old code from `metrics.py`

## Testing
- `pytest -q` *(fails: 163 failed, 351 passed)*

------
https://chatgpt.com/codex/tasks/task_b_685872de8d8083219112673bd0157009