### PR TITLE
Add Celery worker docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,22 @@ The repository includes a `docker-compose.yaml` that runs both the application a
 3.  **Access the application:**
     The API and UI will be available at [http://localhost:8000](http://localhost:8000).
 
+### Starting the Celery Worker
+
+PromptHelix uses Celery for background task processing. A running Redis instance
+is required as both the broker and result backend. The included
+`docker-compose.yaml` starts Redis and sets the `CELERY_BROKER_URL` and
+`CELERY_RESULT_BACKEND_URL` environment variables automatically.
+
+To start a worker locally once Redis is available, run:
+
+```bash
+celery -A prompthelix.celery_app worker -l info
+```
+
+Leave this process running so asynchronous tasks dispatched by the application
+can be executed.
+
 
 ### Manual Deployment
 


### PR DESCRIPTION
## Summary
- document how to launch a Celery worker
- note Redis requirement and docker-compose setup

## Testing
- `python -m prompthelix.cli test` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_685872dfc9808321b6647f1d49bee2f1