### PR TITLE
Fix docs for templates path and entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ You can set these variables in a few ways:
     When the application first runs (e.g., `uvicorn prompthelix.main:app`), the `init_db()` function is called. For SQLite (the default for development), this will create the database file (e.g., `prompthelix.db`) and all necessary tables if they don't already exist. This is convenient for getting started quickly in a development environment.
     For production environments, and for managing database schema changes over time (migrations) in any environment, PromptHelix uses Alembic. See the "Database Migrations" subsection under "Manual Deployment" for details on using Alembic.
     The SQLite database file is not included in the repository and will be created automatically.
+
+    The FastAPI application itself lives in `prompthelix/main.py`. There is no
+    `main.py` at the project root.
 5.  **Run the Web UI (Development Server):**
     ```bash
     uvicorn prompthelix.main:app --reload

--- a/prompthelix/docs/README.md
+++ b/prompthelix/docs/README.md
@@ -17,13 +17,13 @@ The core components of PromptHelix are organized as follows:
 -   `prompthelix/evaluation/`: Modules for evaluating prompt performance.
 -   `prompthelix/genetics/`: Core logic for the genetic algorithm (chromosomes, operators, population), including the Prompt DNA system.
 -   `prompthelix/utils/llm_utils.py`: Utility functions for interacting with various LLM providers.
--   `prompthelix/main.py`: Main FastAPI application entry point for the web server and API.
+-   `prompthelix/main.py`: Main FastAPI application entry point for the web server and API (there is no `main.py` at the repository root).
 -   `prompthelix/schemas/`: Pydantic schemas for data validation and serialization.
 -   `prompthelix/services/`: Business logic and services.
 -   `prompthelix/tests/`: Unit and integration tests.
     -   `unit/`: Contains unit tests for individual components.
     -   `integration/`: Contains integration tests.
--   `prompthelix/ui/`: HTML templates and static files for the web UI.
+-   `prompthelix/templates/`: HTML templates for the web UI. Static assets are in `prompthelix/static/`.
 -   `prompthelix/utils/`: Utility functions and helpers.
 -   `.env.example`: Example environment variable file.
 -   `alembic/`: Alembic migration scripts and configuration for database schema management.


### PR DESCRIPTION
## Summary
- update docs to point to `prompthelix/templates`
- clarify that `prompthelix/main.py` is the main app entry point

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: 163 failed, 351 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_685872e83b008321a28d5e091ab2ebe3