### PR TITLE
Remove unused GA history global

### DIFF
--- a/prompthelix/globals.py
+++ b/prompthelix/globals.py
@@ -24,8 +24,6 @@ websocket_manager = ConnectionManager()
 # Definition for the active Genetic Algorithm runner
 active_ga_runner: Optional["GeneticAlgorithmRunner"] = None
 
-# Fitness history collected during GA runs
-ga_history: list[dict] = []
 
 # Prometheus metrics gauges (initialized lazily by metrics_exporter)
 generation_gauge: Gauge | None = None

--- a/prompthelix/main.py
+++ b/prompthelix/main.py
@@ -113,11 +113,7 @@ async def websocket_dashboard_endpoint(websocket: WebSocket):
     WebSocket endpoint for dashboard real-time updates.
     """
     await websocket_manager.connect(websocket)
-    try:
-        from prompthelix import globals as ph_globals
-        await websocket_manager.send_personal_json({"type": "ga_history", "data": ph_globals.ga_history}, websocket)
-    except Exception as e:  # pragma: no cover - simple log
-        print(f"Failed to send GA history: {e}")
+    # Optionally, GA history could be sent here if retrieved from the database.
     await websocket_manager.broadcast_json({"message": "A new client has connected!"})
     try:
         while True:


### PR DESCRIPTION
## Summary
- remove unused `ga_history` variable
- stop sending GA history on WebSocket connect

## Testing
- `pytest -q tests` *(fails: tests/api/test_metrics.py::test_metrics_endpoint_works, tests/interactive/test_dummy_interactive_general.py::TestDummyInteractiveGeneral::test_general_interactive_fail, tests/test_cli_monkeypatch.py::test_cli_test_command, tests/unit/test_ga_lineage.py::TestGALineageAndMetrics::test_generation_metric_created, tests/unit/test_ga_lineage.py::TestGALineageAndMetrics::test_websocket_payload_includes_lineage, tests/unit/test_meta_learner_logging.py::TestMetaLearnerLogging::test_update_knowledge_base_logging)*

------
https://chatgpt.com/codex/tasks/task_b_685872ea246083219aa224f05fd665bc