### PR TITLE
Use pip version of google-auth-oauthlib

### DIFF
--- a/google_auth_oauthlib/__init__.py
+++ b/google_auth_oauthlib/__init__.py
@@ -1,1 +1,0 @@
-# This space intentionally left blank.

--- a/google_auth_oauthlib/interactive/__init__.py
+++ b/google_auth_oauthlib/interactive/__init__.py
@@ -1,1 +1,0 @@
-# This space intentionally left blank.

--- a/google_auth_oauthlib/interactive/flow.py
+++ b/google_auth_oauthlib/interactive/flow.py
@@ -1,1 +1,0 @@
-# This space intentionally left blank.

--- a/google_auth_oauthlib/oauth2/__init__.py
+++ b/google_auth_oauthlib/oauth2/__init__.py
@@ -1,1 +1,0 @@
-# This space intentionally left blank.

--- a/google_auth_oauthlib/oauth2/client.py
+++ b/google_auth_oauthlib/oauth2/client.py
@@ -1,1 +1,0 @@
-# This space intentionally left blank.

--- a/google_auth_oauthlib/oauth2/flow.py
+++ b/google_auth_oauthlib/oauth2/flow.py
@@ -1,1 +1,0 @@
-# This space intentionally left blank.

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ wandb>=0.17.2 # ==0.16.0 # Added for Weights & Biases integration
 prometheus_client
 mlflow
 pytest-asyncio
+google-auth-oauthlib


### PR DESCRIPTION
## Summary
- remove placeholder `google_auth_oauthlib` vendored package
- depend on `google-auth-oauthlib` in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_6858733f8f20832182af068c875d6bd2