### PR TITLE
Fix: Correct indentation of load_population in PopulationManager

### DIFF
--- a/prompthelix/genetics/engine.py
+++ b/prompthelix/genetics/engine.py
@@ -571,10 +571,10 @@ class PopulationManager:
         except (IOError, OSError) as e:
             logger.error(f"Error saving population to {file_path}: {e}", exc_info=True)
 
-def load_population(self, file_path: Optional[str] = None) -> None:
-    file_path = file_path or self.population_path
-    if not file_path or not os.path.exists(file_path):
-        logger.info(f"PopulationManager: No population file at {file_path}; starting fresh.")
+    def load_population(self, file_path: Optional[str] = None) -> None:
+        file_path = file_path or self.population_path
+        if not file_path or not os.path.exists(file_path):
+            logger.info(f"PopulationManager: No population file at {file_path}; starting fresh.")
         self.population = []
         self.generation_number = 0
         return


### PR DESCRIPTION
The load_population function was incorrectly defined at the module level instead of being a method of the PopulationManager class. This caused a SyntaxError because the Python interpreter expected an except or finally block after a try statement in the preceding save_population method, but instead encountered the definition of broadcast_ga_update.

This commit corrects the indentation of load_population, making it a method of the PopulationManager class and resolving the SyntaxError.