### PR TITLE
Fix: Resolve NameError for configure_logging in main.py

### DIFF
--- a/prompthelix/main.py
+++ b/prompthelix/main.py
@@ -31,17 +31,10 @@ from prompthelix.utils.metrics_exporter import start_exporter_if_enabled
 start_exporter_if_enabled() # Start Prometheus client HTTP server if enabled
 # --- End Prometheus Metrics Exporter ---
 
-
-from prompthelix.utils import setup_logging # This is a duplicate import, setup_logging() was already called
-
-# setup_logging() # Duplicate call
-
-from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
-
-# Configure logging as soon as possible
-configure_logging(settings.DEBUG)
-
-
+# Logging is already configured by the call to setup_logging() near the top of this file.
+# The function `configure_logging` does not exist, and `setup_logging` (from prompthelix.logging_config)
+# does not take arguments as it accesses `settings.DEBUG` internally.
+# Removing the erroneous call to `configure_logging` and duplicate imports/calls.
 
 # Call init_db to create database tables on startup
 init_db()  # Initialize database and tables on startup


### PR DESCRIPTION
A `NameError` occurred because `configure_logging` was called in `prompthelix/main.py` but was not defined or imported. Logging is already correctly initialized earlier in the file by a call to `setup_logging()` from `prompthelix.logging_config`.

This commit removes the erroneous call to `configure_logging`. It also removes a duplicate import of `setup_logging` and a commented-out redundant call to `setup_logging` for clarity.