### PR TITLE
Fix: Await calls to async llm_utils.call_llm_api

### DIFF
--- a/prompthelix/agents/results_evaluator.py
+++ b/prompthelix/agents/results_evaluator.py
@@ -359,7 +359,7 @@ Example:
 
         # Pass self.db if available and needed by call_llm_api. Assuming self.db might be None.
         # call_llm_api is designed to handle db=None.
-        response_str = call_llm_api(prompt_str_for_llm, provider=self.llm_provider, model=self.evaluation_llm_model, db=self.db)
+        response_str = await call_llm_api(prompt_str_for_llm, provider=self.llm_provider, model=self.evaluation_llm_model, db=self.db)
 
         if response_str in LLM_API_ERROR_STRINGS:
             logger.warning(f"Agent '{self.agent_id}': LLM call for content analysis failed with error code: {response_str}. Using fallback metrics.")

--- a/prompthelix/api/routes.py
+++ b/prompthelix/api/routes.py
@@ -495,8 +495,8 @@ def list_chromosomes_for_run(
 async def test_llm_prompt_route(request_data: schemas.LLMTestRequest, db: DbSession = Depends(get_db)):
 
     try:
-        # llm_utils.call_llm_api is a synchronous function, so remove await
-        response_text = llm_utils.call_llm_api(
+        # llm_utils.call_llm_api is an asynchronous function, so it requires await
+        response_text = await llm_utils.call_llm_api(
             prompt=request_data.prompt_text, provider=request_data.llm_service, db=db
         )
         try:


### PR DESCRIPTION
Ensured that all calls to the asynchronous function `llm_utils.call_llm_api` are properly awaited.

Changes made in:
- prompthelix/api/routes.py (in test_llm_prompt_route)
- prompthelix/agents/results_evaluator.py (in _analyze_content method)